### PR TITLE
Fiks indeks-referanse i trigger

### DIFF
--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -5,7 +5,7 @@ resource "null_resource" "lambda_exporter" {
   # (some local-exec provisioner blocks, presumably...)
 
   triggers = {
-    index : "${base64sha256(file("${path.module}/../../${var.function_folder_location}/main.py"))}"
+    index : base64sha256(file("${path.module}/../../${var.function_folder_location}/main.py"))
   }
 }
 


### PR DESCRIPTION
Får `Invalid value for "path" parameter: no file exists at...` når vi bruker modulen