### PR TITLE
Referer source-directory til riktig mappe

### DIFF
--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -1,6 +1,14 @@
+terraform {
+  required_providers {
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.2.0"
+    }
+  }
+}
+
 # Alternativ beskrevet i https://github.com/hashicorp/terraform-provider-null/issues/86
 # Må gjøre dette på sikt fordi null_resource er deprecated
-
 resource "null_resource" "lambda_exporter" {
   # (some local-exec provisioner blocks, presumably...)
 

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -7,32 +7,10 @@ terraform {
   }
 }
 
-# Alternativ beskrevet i https://github.com/hashicorp/terraform-provider-null/issues/86
-# Må gjøre dette på sikt fordi null_resource er deprecated
-resource "null_resource" "lambda_exporter" {
-  # (some local-exec provisioner blocks, presumably...)
-
-  triggers = {
-    index : base64sha256(file("${path.module}/../../${var.function_folder_location}/main.py"))
-  }
-}
-
-data "null_data_source" "wait_for_lambda_exporter" {
-  inputs = {
-    # This ensures that this data resource will not be evaluated until
-    # after the null_resource has been created.
-    lambda_exporter_id = null_resource.lambda_exporter.id
-
-    # This value gives us something to implicitly depend on
-    # in the archive_file below.
-    source_dir = "${path.module}/../../${var.function_folder_location}"
-  }
-}
-
 data "archive_file" "this" {
   type        = "zip"
   output_path = "${path.module}/lambda-files.zip"
-  source_dir  = data.null_data_source.wait_for_lambda_exporter.outputs["source_dir"]
+  source_dir  = var.function_folder_location
   excludes    = var.excludes
 }
 

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    archive = {
-      source  = "hashicorp/archive"
-      version = "~> 2.2.0"
-    }
-  }
-}
-
 data "archive_file" "this" {
   type        = "zip"
   output_path = "${path.module}/lambda-files.zip"


### PR DESCRIPTION
## Bakgrunn
Path-modulen til en remote Terraform.modul klarer ikke å resolve seg selv, så vi får ikke brukt modulen i andre repos.

## Løsning
Fjerner `null_resource` og setter heller `source_dir` til input-variabelen `function_folder_location`
