### PR TITLE
Eksponer outputs fra dbx_workspace_create

### DIFF
--- a/terraform/iam_module/dbx_workspace_create/outputs.tf
+++ b/terraform/iam_module/dbx_workspace_create/outputs.tf
@@ -1,0 +1,7 @@
+output "workspace_url" {
+  value = databricks_mws_workspaces.this.workspace_url
+}
+
+output "workspace_id" {
+  value = databricks_mws_workspaces.this.workspace_id
+}

--- a/terraform/iam_module/outputs.tf
+++ b/terraform/iam_module/outputs.tf
@@ -1,0 +1,7 @@
+output "workspace_url" {
+  value = module.workspace_create.workspace_url
+}
+
+output "workspace_id" {
+  value = module.workspace_create.workspace_id
+}


### PR DESCRIPTION
Nå som vi skal lage ett workspace per miljø trenger vi ikke legge inn `dbx_workspace_create` i IAM-repoet. Det gjør også at vi kan eksponere outputs (workspace-url og -id) slik at vi slipper å copy-paste disse verdiene i infrastruktur-repoet