### PR TITLE
Endre prefix på workspace-navn

### DIFF
--- a/terraform/iam_module/dbx_workspace_create/main.tf
+++ b/terraform/iam_module/dbx_workspace_create/main.tf
@@ -1,7 +1,11 @@
+locals {
+  name_prefix = env == "prod" ? "" : "${var.env}-"
+}
+
 module "create_vpc_for_databricks" {
   source = "../gcp_vpc"
 
-  name_prefix  = "${var.name_prefix}-dbx"
+  name_prefix  = "${local.name_prefix}dbx"
   name_postfix = var.name_postfix
   project_id   = var.project_id
   region       = var.region
@@ -10,7 +14,7 @@ module "create_vpc_for_databricks" {
 resource "databricks_mws_networks" "this" {
   provider     = databricks.accounts
   account_id   = var.databricks_account_id
-  network_name = "${var.name_prefix}-vpc-${var.name_postfix}"
+  network_name = "${local.name_prefix}vpc-${var.name_postfix}"
   gcp_network_info {
     network_project_id    = var.project_id
     vpc_id                = module.create_vpc_for_databricks.vpc_name
@@ -24,7 +28,7 @@ resource "databricks_mws_networks" "this" {
 resource "databricks_mws_workspaces" "this" {
   provider       = databricks.accounts
   account_id     = var.databricks_account_id
-  workspace_name = "${var.name_prefix}-dbxws-${var.env}"
+  workspace_name = "${local.name_prefix}workspace-${var.name_postfix}"
   location       = var.region
 
   cloud_resource_container {

--- a/terraform/iam_module/gcp_vpc/main.tf
+++ b/terraform/iam_module/gcp_vpc/main.tf
@@ -1,11 +1,11 @@
 resource "google_compute_network" "vpc_network" {
   project                 = var.project_id
-  name                    = "${var.name_prefix}-vpc-${var.name_postfix}"
+  name                    = "${var.name_prefix}vpc-${var.name_postfix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" {
-  name          = "${var.name_prefix}-ip-ranges-${var.name_postfix}"
+  name          = "${var.name_prefix}ip-ranges-${var.name_postfix}"
   ip_cidr_range = "10.0.0.0/16"
   region        = var.region
   network       = google_compute_network.vpc_network.id
@@ -21,13 +21,13 @@ resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" 
 }
 
 resource "google_compute_router" "router" {
-  name    = "${var.name_prefix}-router-${var.name_postfix}"
+  name    = "${var.name_prefix}router-${var.name_postfix}"
   region  = var.region
   network = google_compute_network.vpc_network.id
 }
 
 resource "google_compute_router_nat" "nat" {
-  name                               = "${var.name_prefix}-router-nat-${var.name_postfix}"
+  name                               = "${var.name_prefix}router-nat-${var.name_postfix}"
   router                             = google_compute_router.router.name
   region                             = var.region
   nat_ip_allocate_option             = "AUTO_ONLY"


### PR DESCRIPTION
Vi ønsker å ha forklarlige og samtidig separerbare navn for workspaces. Derfor lager vi en lokal variabel for prefix som tar med `var.env` hvis miljøet er sandbox og ingenting hvis miljøet er prod. Da ser workspacene slik ut:

For prod:
- `workspace-dev`
- `workspace-test`
- `workspace-prod`

For sandbox:
- `sandbox-workspace-dev`
- `sandbox-workspace-test`
- `sandbox-workspace-prod`