### PR TITLE
TD-429: Flytt opprettelse av cluster fra dask-infrastructure

### DIFF
--- a/terraform/iam_module/backend.tf
+++ b/terraform/iam_module/backend.tf
@@ -5,7 +5,7 @@ terraform {
     }
     databricks = {
       source                = "databricks/databricks"
-      configuration_aliases = [databricks.accounts]
+      configuration_aliases = [databricks.accounts, databricks.workspace]
     }
   }
 }

--- a/terraform/iam_module/dbx_workspace_cluster_create/backend.tf
+++ b/terraform/iam_module/dbx_workspace_cluster_create/backend.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    databricks = {
+      source                = "databricks/databricks"
+      configuration_aliases = [databricks.workspace]
+    }
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}

--- a/terraform/iam_module/dbx_workspace_cluster_create/main.tf
+++ b/terraform/iam_module/dbx_workspace_cluster_create/main.tf
@@ -17,11 +17,11 @@ data "databricks_spark_version" "latest_lts" {
   long_term_support = true
 }
 
-resource "google_service_account" "service_account" {
+resource "google_service_account" "cluster_service_account" {
   project      = var.project_id
   account_id   = "cluster-${var.workspace_env}-sa"
   display_name = "Service Account ${var.workspace_env}"
-  description  = "Service account som bare tilhører ${var.workspace_env}. I utgangspunktet har denne kun tilgang til der felles init-scripts blir lagret."
+  description  = "Service account for clusteret som bare tilhører ${var.workspace_env}."
 }
 
 #resource "google_storage_bucket_iam_member" "member" {
@@ -62,7 +62,7 @@ resource "databricks_cluster" "shared_autoscaling" {
   gcp_attributes {
     availability           = "PREEMPTIBLE_WITH_FALLBACK_GCP"
     zone_id                = "AUTO"
-    google_service_account = google_service_account.service_account.email
+    google_service_account = google_service_account.cluster_service_account.email
   }
 
 }

--- a/terraform/iam_module/dbx_workspace_cluster_create/main.tf
+++ b/terraform/iam_module/dbx_workspace_cluster_create/main.tf
@@ -19,9 +19,9 @@ data "databricks_spark_version" "latest_lts" {
 
 resource "google_service_account" "service_account" {
   project      = var.project_id
-  account_id   = "cluster-${var.project_id}-sa"
-  display_name = "Service Account ${var.project_id}"
-  description  = "Service account som bare tilhører ${var.project_id}. I utgangspunktet har denne kun tilgang til der felles init-scripts blir lagret."
+  account_id   = "cluster-${var.workspace_env}-sa"
+  display_name = "Service Account ${var.workspace_env}"
+  description  = "Service account som bare tilhører ${var.workspace_env}. I utgangspunktet har denne kun tilgang til der felles init-scripts blir lagret."
 }
 
 #resource "google_storage_bucket_iam_member" "member" {

--- a/terraform/iam_module/dbx_workspace_cluster_create/main.tf
+++ b/terraform/iam_module/dbx_workspace_cluster_create/main.tf
@@ -24,11 +24,11 @@ resource "google_service_account" "service_account" {
   description  = "Service account som bare tilhører ${var.project_id}. I utgangspunktet har denne kun tilgang til der felles init-scripts blir lagret."
 }
 
-resource "google_storage_bucket_iam_member" "member" {
-  bucket = var.init_script_bucket_name
-  role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.service_account.email}"
-}
+#resource "google_storage_bucket_iam_member" "member" {
+#  bucket = var.init_script_bucket_name
+#  role   = "roles/storage.objectViewer"
+#  member = "serviceAccount:${google_service_account.service_account.email}"
+#}
 
 resource "databricks_cluster" "shared_autoscaling" {
   provider                = databricks.workspace

--- a/terraform/iam_module/dbx_workspace_cluster_create/main.tf
+++ b/terraform/iam_module/dbx_workspace_cluster_create/main.tf
@@ -1,0 +1,68 @@
+locals {
+  python_packages = [
+    "shapely",
+    "apache-sedona",
+  ]
+}
+
+data "databricks_node_type" "smallest" {
+  provider    = databricks.workspace
+  local_disk  = true
+  min_cores   = 4
+  gb_per_core = 1
+}
+
+data "databricks_spark_version" "latest_lts" {
+  provider          = databricks.workspace
+  long_term_support = true
+}
+
+resource "google_service_account" "service_account" {
+  project      = var.project_id
+  account_id   = "cluster-${var.project_id}-sa"
+  display_name = "Service Account ${var.project_id}"
+  description  = "Service account som bare tilhører ${var.project_id}. I utgangspunktet har denne kun tilgang til der felles init-scripts blir lagret."
+}
+
+resource "google_storage_bucket_iam_member" "member" {
+  bucket = var.init_script_bucket_name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+resource "databricks_cluster" "shared_autoscaling" {
+  provider                = databricks.workspace
+  cluster_name            = "${var.project_id}-kluster"
+  spark_version           = data.databricks_spark_version.latest_lts.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  data_security_mode      = "USER_ISOLATION"
+  autotermination_minutes = 60
+  autoscale {
+    min_workers = 1
+    max_workers = 2
+  }
+  #   init_scripts {
+  #     gcs {
+  #       destination = "gs://${var.init_script_bucket_name}/dask-dbx-init.sh"
+  #     }
+  #   }
+  #   spark_conf = {
+  #     "spark.kryo.registrator" : "org.apache.sedona.core.serde.SedonaKryoRegistrator",
+  #     "spark.serializer" : "org.apache.spark.serializer.KryoSerializer",
+  #     "spark.sql.extensions" : "org.apache.sedona.viz.sql.SedonaVizExtensions,org.apache.sedona.sql.SedonaSqlExtensions",
+  #   }
+  dynamic "library" {
+    for_each = toset(local.python_packages)
+    content {
+      pypi {
+        package = library.value
+      }
+    }
+  }
+  gcp_attributes {
+    availability           = "PREEMPTIBLE_WITH_FALLBACK_GCP"
+    zone_id                = "AUTO"
+    google_service_account = google_service_account.service_account.email
+  }
+
+}

--- a/terraform/iam_module/dbx_workspace_cluster_create/variables.tf
+++ b/terraform/iam_module/dbx_workspace_cluster_create/variables.tf
@@ -1,23 +1,9 @@
-variable "name_postfix" {
-  description = "String to be appended at the end of resource name properties."
-  default     = "tf-managed"
-}
-
 variable "project_id" {
   description = "The Id of the project for the resources to create"
 }
 
-variable "region" {
-  description = "Location for Databricks workspace / region for GCP vpc. Databricks location should match vpc region."
-  default     = "europe-west1"
-}
-
-variable "databricks_account_id" {
-  description = "Account ID found on https://accounts.gcp.databricks.com/"
-}
-
 variable "env" {
-  description = "Environment for the resources to create"
+  description = "Environment"
 }
 
 variable "deploy_service_account" {

--- a/terraform/iam_module/dbx_workspace_cluster_create/variables.tf
+++ b/terraform/iam_module/dbx_workspace_cluster_create/variables.tf
@@ -11,7 +11,7 @@ variable "deploy_service_account" {
 }
 
 variable "workspace_env" {
-  description = "The environment of the workspace"
+  description = "String to be appended at the end of resource name properties (dev/test/prod)"
 }
 
 #variable "init_script_bucket_name" {

--- a/terraform/iam_module/dbx_workspace_cluster_create/variables.tf
+++ b/terraform/iam_module/dbx_workspace_cluster_create/variables.tf
@@ -10,6 +10,10 @@ variable "deploy_service_account" {
   description = "Need to set this to Databricks account owner SA to use Databricks account API, and Databricks workspace owner to use Databricks workspace API."
 }
 
+variable "workspace_env" {
+  description = "The environment of the workspace"
+}
+
 #variable "init_script_bucket_name" {
 #  description = "The bucket name in GCP where the init scripts is stored. The service account associated to the workspace/team cluster will have read access to the init script base bucket."
 #}

--- a/terraform/iam_module/dbx_workspace_cluster_create/variables.tf
+++ b/terraform/iam_module/dbx_workspace_cluster_create/variables.tf
@@ -13,7 +13,3 @@ variable "deploy_service_account" {
 #variable "init_script_bucket_name" {
 #  description = "The bucket name in GCP where the init scripts is stored. The service account associated to the workspace/team cluster will have read access to the init script base bucket."
 #}
-
-variable "read_bucket_content_role" {
-  description = "The custom role created to grant read access to both content and metadata of a GCS bucket"
-}

--- a/terraform/iam_module/dbx_workspace_cluster_create/variables.tf
+++ b/terraform/iam_module/dbx_workspace_cluster_create/variables.tf
@@ -10,9 +10,9 @@ variable "deploy_service_account" {
   description = "Need to set this to Databricks account owner SA to use Databricks account API, and Databricks workspace owner to use Databricks workspace API."
 }
 
-variable "init_script_bucket_name" {
-  description = "The bucket name in GCP where the init scripts is stored. The service account associated to the workspace/team cluster will have read access to the init script base bucket."
-}
+#variable "init_script_bucket_name" {
+#  description = "The bucket name in GCP where the init scripts is stored. The service account associated to the workspace/team cluster will have read access to the init script base bucket."
+#}
 
 variable "read_bucket_content_role" {
   description = "The custom role created to grant read access to both content and metadata of a GCS bucket"

--- a/terraform/iam_module/dbx_workspace_create/main.tf
+++ b/terraform/iam_module/dbx_workspace_create/main.tf
@@ -6,7 +6,7 @@ module "create_vpc_for_databricks" {
   source = "../gcp_vpc"
 
   name_prefix  = "${local.name_prefix}dbx"
-  name_postfix = var.name_postfix
+  workspace_env = var.workspace_env
   project_id   = var.project_id
   region       = var.region
 }
@@ -14,7 +14,7 @@ module "create_vpc_for_databricks" {
 resource "databricks_mws_networks" "this" {
   provider     = databricks.accounts
   account_id   = var.databricks_account_id
-  network_name = "${local.name_prefix}vpc-${var.name_postfix}"
+  network_name = "${local.name_prefix}vpc-${var.workspace_env}"
   gcp_network_info {
     network_project_id    = var.project_id
     vpc_id                = module.create_vpc_for_databricks.vpc_name
@@ -28,7 +28,7 @@ resource "databricks_mws_networks" "this" {
 resource "databricks_mws_workspaces" "this" {
   provider       = databricks.accounts
   account_id     = var.databricks_account_id
-  workspace_name = "${local.name_prefix}workspace-${var.name_postfix}"
+  workspace_name = "${local.name_prefix}workspace-${var.workspace_env}"
   location       = var.region
 
   cloud_resource_container {

--- a/terraform/iam_module/dbx_workspace_create/variables.tf
+++ b/terraform/iam_module/dbx_workspace_create/variables.tf
@@ -1,6 +1,5 @@
 variable "workspace_env" {
-  description = "String to be appended at the end of resource name properties."
-  default     = "tf-managed"
+  description = "String to be appended at the end of resource name properties (dev/test/prod)"
 }
 
 variable "project_id" {

--- a/terraform/iam_module/dbx_workspace_create/variables.tf
+++ b/terraform/iam_module/dbx_workspace_create/variables.tf
@@ -1,4 +1,4 @@
-variable "name_postfix" {
+variable "workspace_env" {
   description = "String to be appended at the end of resource name properties."
   default     = "tf-managed"
 }

--- a/terraform/iam_module/gcp_vpc/main.tf
+++ b/terraform/iam_module/gcp_vpc/main.tf
@@ -1,11 +1,11 @@
 resource "google_compute_network" "vpc_network" {
   project                 = var.project_id
-  name                    = "${var.name_prefix}vpc-${var.name_postfix}"
+  name                    = "${var.name_prefix}vpc-${var.workspace_env}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" {
-  name          = "${var.name_prefix}ip-ranges-${var.name_postfix}"
+  name          = "${var.name_prefix}ip-ranges-${var.workspace_env}"
   ip_cidr_range = "10.0.0.0/16"
   region        = var.region
   network       = google_compute_network.vpc_network.id
@@ -21,13 +21,13 @@ resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" 
 }
 
 resource "google_compute_router" "router" {
-  name    = "${var.name_prefix}router-${var.name_postfix}"
+  name    = "${var.name_prefix}router-${var.workspace_env}"
   region  = var.region
   network = google_compute_network.vpc_network.id
 }
 
 resource "google_compute_router_nat" "nat" {
-  name                               = "${var.name_prefix}router-nat-${var.name_postfix}"
+  name                               = "${var.name_prefix}router-nat-${var.workspace_env}"
   router                             = google_compute_router.router.name
   region                             = var.region
   nat_ip_allocate_option             = "AUTO_ONLY"

--- a/terraform/iam_module/gcp_vpc/variables.tf
+++ b/terraform/iam_module/gcp_vpc/variables.tf
@@ -2,7 +2,7 @@ variable "name_prefix" {
   description = "String to be appended at the beginning of resource name properties."
 }
 
-variable "name_postfix" {
+variable "workspace_env" {
   default     = "tf-managed"
   description = "Name postfix for the vpc resources."
 }

--- a/terraform/iam_module/main.tf
+++ b/terraform/iam_module/main.tf
@@ -7,7 +7,7 @@ module "workspace_create" {
   project_id            = var.project_id
   region                = var.region
   env                   = var.env
-  name_postfix           = var.name_postfix
+  workspace_env           = var.workspace_env
 }
 
 module "create_cluster_for_ws" {

--- a/terraform/iam_module/main.tf
+++ b/terraform/iam_module/main.tf
@@ -15,7 +15,6 @@ module "create_cluster_for_ws" {
   project_id               = var.project_id
   env                      = var.env
   deploy_service_account   = var.deploy_service_account
-  read_bucket_content_role = var.read_bucket_content_role
   #init_script_bucket_name  = var.init_script_bucket_name
 
   providers = {

--- a/terraform/iam_module/main.tf
+++ b/terraform/iam_module/main.tf
@@ -7,15 +7,16 @@ module "workspace_create" {
   project_id            = var.project_id
   region                = var.region
   env                   = var.env
-  workspace_env           = var.workspace_env
+  workspace_env         = var.workspace_env
 }
 
 module "create_cluster_for_ws" {
-  source                   = "./dbx_workspace_cluster_create"
-  project_id               = var.project_id
-  env                      = var.env
-  deploy_service_account   = var.deploy_service_account
-  depends_on = [
+  source                 = "./dbx_workspace_cluster_create"
+  project_id             = var.project_id
+  env                    = var.env
+  deploy_service_account = var.deploy_service_account
+  workspace_env          = var.workspace_env
+  depends_on             = [
     module.workspace_create
   ]
   #init_script_bucket_name  = var.init_script_bucket_name

--- a/terraform/iam_module/main.tf
+++ b/terraform/iam_module/main.tf
@@ -15,6 +15,9 @@ module "create_cluster_for_ws" {
   project_id               = var.project_id
   env                      = var.env
   deploy_service_account   = var.deploy_service_account
+  depends_on = [
+    module.workspace_create
+  ]
   #init_script_bucket_name  = var.init_script_bucket_name
 
   providers = {

--- a/terraform/iam_module/main.tf
+++ b/terraform/iam_module/main.tf
@@ -15,8 +15,8 @@ module "create_cluster_for_ws" {
   project_id               = var.project_id
   env                      = var.env
   deploy_service_account   = var.deploy_service_account
-  init_script_bucket_name  = var.init_script_bucket_name
   read_bucket_content_role = var.read_bucket_content_role
+  #init_script_bucket_name  = var.init_script_bucket_name
 
   providers = {
     databricks.workspace = databricks.workspace

--- a/terraform/iam_module/main.tf
+++ b/terraform/iam_module/main.tf
@@ -1,10 +1,3 @@
-locals {
-  landing_sa_roles = [
-    "roles/storage.objectViewer",
-    "roles/storage.legacyBucketReader",
-  ]
-}
-
 module "workspace_create" {
   source    = "./dbx_workspace_create/"
   providers = {
@@ -17,25 +10,15 @@ module "workspace_create" {
   name_postfix           = var.name_postfix
 }
 
-resource "random_id" "bucket_suffix" {
-  byte_length = 4
-}
+module "create_cluster_for_ws" {
+  source                   = "./dbx_workspace_cluster_create"
+  project_id               = var.project_id
+  env                      = var.env
+  deploy_service_account   = var.deploy_service_account
+  init_script_bucket_name  = var.init_script_bucket_name
+  read_bucket_content_role = var.read_bucket_content_role
 
-resource "google_storage_bucket" "landing_zone" {
-  location = var.region
-  name     = "landing-zone-${var.env}-${var.name_postfix}-${random_id.bucket_suffix.hex}"
-}
-
-resource "google_service_account" "service_account" {
-  project      = var.project_id
-  account_id   = "cluster-${var.name_postfix}-sa"
-  display_name = "Service Account ${var.name_postfix}"
-  description  = "Service account som bare tilhører ${var.name_postfix}. I utgangspunktet har denne kun tilgang til der felles init-scripts blir lagret."
-}
-
-resource "google_storage_bucket_iam_member" "member" {
-  for_each = toset(local.landing_sa_roles)
-  bucket   = google_storage_bucket.landing_zone.name
-  role     = each.value
-  member   = "serviceAccount:${google_service_account.service_account.email}"
+  providers = {
+    databricks.workspace = databricks.workspace
+  }
 }

--- a/terraform/iam_module/variables.tf
+++ b/terraform/iam_module/variables.tf
@@ -24,9 +24,9 @@ variable "deploy_service_account" {
   description = "Need to set this to Databricks account owner SA to use Databricks account API, and Databricks workspace owner to use Databricks workspace API."
 }
 
-variable "init_script_bucket_name" {
-  description = "The bucket name in GCP where the init scripts is stored. The service account associated to the workspace/team cluster will have read access to the init script base bucket."
-}
+#variable "init_script_bucket_name" {
+#  description = "The bucket name in GCP where the init scripts is stored. The service account associated to the workspace/team cluster will have read access to the init script base bucket."
+#}
 
 variable "read_bucket_content_role" {
   description = "The custom role created to grant read access to both content and metadata of a GCS bucket"

--- a/terraform/iam_module/variables.tf
+++ b/terraform/iam_module/variables.tf
@@ -1,6 +1,5 @@
 variable "workspace_env" {
-  description = "String to be appended at the end of resource name properties."
-  default     = "tf-managed"
+  description = "String to be appended at the end of resource name properties (dev/test/prod)"
 }
 
 variable "project_id" {

--- a/terraform/iam_module/variables.tf
+++ b/terraform/iam_module/variables.tf
@@ -27,7 +27,3 @@ variable "deploy_service_account" {
 #variable "init_script_bucket_name" {
 #  description = "The bucket name in GCP where the init scripts is stored. The service account associated to the workspace/team cluster will have read access to the init script base bucket."
 #}
-
-variable "read_bucket_content_role" {
-  description = "The custom role created to grant read access to both content and metadata of a GCS bucket"
-}

--- a/terraform/iam_module/variables.tf
+++ b/terraform/iam_module/variables.tf
@@ -1,4 +1,4 @@
-variable "name_postfix" {
+variable "workspace_env" {
   description = "String to be appended at the end of resource name properties."
   default     = "tf-managed"
 }


### PR DESCRIPTION
Vi mangler et compute-cluster som er knyttet til hvert Databricks workspace. Dette må vi ha for at det skal gå an å kjøre feks en celle i notebook. Flytter derfor opprettelsen av workspace-clusteret inn i iam-modulen slik at det opprettes et cluster per workspace i samme flyt som opprettelsen av workspacet. 

Fjernet samtidig landingssone-bøtta, da vi ikke trenger det lenger (oppgave til det ligger [her](https://kartverket.atlassian.net/jira/software/projects/TD/boards/99?selectedIssue=TD-433)). 