### PR TITLE
Opprette kobling til unity catalog ved ws opprettelse

### DIFF
--- a/terraform/iam_module/dbx_workspace_create/main.tf
+++ b/terraform/iam_module/dbx_workspace_create/main.tf
@@ -42,3 +42,9 @@ resource "databricks_mws_workspaces" "this" {
     master_ip_range   = "10.3.0.0/28"
   }
 }
+
+resource "databricks_metastore_assignment" "this" {
+  provider     = databricks.workspace
+  metastore_id = var.metastore_id
+  workspace_id = databricks_mws_workspaces.this.workspace_id
+}

--- a/terraform/iam_module/dbx_workspace_create/variables.tf
+++ b/terraform/iam_module/dbx_workspace_create/variables.tf
@@ -17,3 +17,7 @@ variable "databricks_account_id" {
 variable "env" {
   description = "Environment for the resources to create"
 }
+
+variable "metastore_id" {
+  description = "The metastore_id used to share the unity catalog between workspaces"
+}

--- a/terraform/iam_module/main.tf
+++ b/terraform/iam_module/main.tf
@@ -8,6 +8,7 @@ module "workspace_create" {
   region                = var.region
   env                   = var.env
   workspace_env         = var.workspace_env
+  metastore_id          = var.metastore_id
 }
 
 module "create_cluster_for_ws" {

--- a/terraform/iam_module/variables.tf
+++ b/terraform/iam_module/variables.tf
@@ -23,6 +23,10 @@ variable "deploy_service_account" {
   description = "Need to set this to Databricks account owner SA to use Databricks account API, and Databricks workspace owner to use Databricks workspace API."
 }
 
+variable "metastore_id" {
+  description = "The metastore_id used to share the unity catalog between workspaces"
+}
+
 #variable "init_script_bucket_name" {
 #  description = "The bucket name in GCP where the init scripts is stored. The service account associated to the workspace/team cluster will have read access to the init script base bucket."
 #}


### PR DESCRIPTION
For at vi skal kunne gi tilgang til WS på accountnivå må WSene være tilknyttet unity catalogen. Denne PRen fikser dette.