### PR TITLE
databricks_grants resource metastore is used to set privileges on the…

### DIFF
--- a/terraform/modules/dbx_uc_create_catalog/main.tf
+++ b/terraform/modules/dbx_uc_create_catalog/main.tf
@@ -41,7 +41,6 @@ resource "databricks_catalog" "create_team_metastore_catalog" {
 
 resource "databricks_grants" "grants_on_catalog" {
   catalog   = databricks_catalog.create_team_metastore_catalog.name
-  metastore = var.metastore_id
   provider  = databricks.workspace
   grant {
     principal  = var.team_name


### PR DESCRIPTION
… metastore level. Not to refere to which metastore the catalog belonges to.