### PR TITLE
Schema name can only contain lower case letters

### DIFF
--- a/terraform/iam_module/main.tf
+++ b/terraform/iam_module/main.tf
@@ -39,7 +39,7 @@ module "create_uc_schema" {
   catalog_name       = module.create_uc_catalog.catalog_name
   env                = var.env
   schema_description = "Schema for external resources and volumes"
-  schema_name        = "EXTERNAL"
+  schema_name        = "external"
   team_name          = var.team_name
   metastore_id       = var.metastore_id
 }

--- a/terraform/modules/dbx_uc_create_catalog/main.tf
+++ b/terraform/modules/dbx_uc_create_catalog/main.tf
@@ -10,9 +10,16 @@ resource "databricks_storage_credential" "gcs_catalog_bucket_creds" {
   databricks_gcp_service_account {}
 }
 
-resource "google_storage_bucket_iam_member" "give_sa_admin_role" {
+resource "google_storage_bucket_iam_member" "SA_legacyBucketOwner_role" {
   bucket     = var.gcs_bucket_name
   role       = "roles/storage.legacyBucketOwner"
+  member     = "serviceAccount:${databricks_storage_credential.gcs_catalog_bucket_creds.databricks_gcp_service_account[0].email}"
+  depends_on = [databricks_storage_credential.gcs_catalog_bucket_creds]
+}
+
+resource "google_storage_bucket_iam_member" "SA_storageAdmin_role" {
+  bucket     = var.gcs_bucket_name
+  role       = "roles/storage.storageAdmin"
   member     = "serviceAccount:${databricks_storage_credential.gcs_catalog_bucket_creds.databricks_gcp_service_account[0].email}"
   depends_on = [databricks_storage_credential.gcs_catalog_bucket_creds]
 }

--- a/terraform/modules/dbx_uc_create_catalog/main.tf
+++ b/terraform/modules/dbx_uc_create_catalog/main.tf
@@ -41,7 +41,6 @@ resource "databricks_catalog" "create_team_metastore_catalog" {
 
 resource "databricks_grants" "grants_on_catalog" {
   catalog   = databricks_catalog.create_team_metastore_catalog.name
-  metastore = var.metastore_id
   provider  = databricks.workspace
   grant {
     principal  = var.team_name

--- a/terraform/modules/dbx_uc_create_catalog/main.tf
+++ b/terraform/modules/dbx_uc_create_catalog/main.tf
@@ -21,7 +21,7 @@ resource "google_storage_bucket_iam_member" "SA_storageAdmin_role" {
   bucket     = var.gcs_bucket_name
   role       = "roles/storage.storageAdmin"
   member     = "serviceAccount:${databricks_storage_credential.gcs_catalog_bucket_creds.databricks_gcp_service_account[0].email}"
-  depends_on = [databricks_storage_credential.gcs_catalog_bucket_creds]
+  depends_on = [google_storage_bucket_iam_member.SA_legacyBucketOwner_role]
 }
 
 resource "databricks_external_location" "external_location_to_add" {
@@ -29,7 +29,7 @@ resource "databricks_external_location" "external_location_to_add" {
   name            = "gcs-${var.gcs_bucket_name}-${local.name_postfix}"
   url             = "gs://${var.gcs_bucket_name}"
   credential_name = databricks_storage_credential.gcs_catalog_bucket_creds.name
-  depends_on      = [google_storage_bucket_iam_member.give_sa_admin_role]
+  depends_on      = [google_storage_bucket_iam_member.SA_storageAdmin_role]
 }
 
 resource "databricks_catalog" "create_team_metastore_catalog" {

--- a/terraform/modules/dbx_uc_create_catalog/main.tf
+++ b/terraform/modules/dbx_uc_create_catalog/main.tf
@@ -19,7 +19,7 @@ resource "google_storage_bucket_iam_member" "SA_legacyBucketOwner_role" {
 
 resource "google_storage_bucket_iam_member" "SA_storageAdmin_role" {
   bucket     = var.gcs_bucket_name
-  role       = "roles/storage.storageAdmin"
+  role       = "roles/storage.admin"
   member     = "serviceAccount:${databricks_storage_credential.gcs_catalog_bucket_creds.databricks_gcp_service_account[0].email}"
   depends_on = [google_storage_bucket_iam_member.SA_legacyBucketOwner_role]
 }

--- a/terraform/modules/dbx_uc_create_schema/main.tf
+++ b/terraform/modules/dbx_uc_create_schema/main.tf
@@ -6,7 +6,7 @@ resource "databricks_schema" "create_external_schema_in_catalog" {
   provider     = databricks.workspace
   metastore_id = var.metastore_id
   catalog_name = var.catalog_name
-  name         = "${var.schema_name}${local.name_postfix}"
+  name         = lower("${var.schema_name}${local.name_postfix}")
   comment      = var.schema_description
   properties = {
     team = var.team_name

--- a/terraform/modules/dbx_uc_gcs_volume/main.tf
+++ b/terraform/modules/dbx_uc_gcs_volume/main.tf
@@ -33,9 +33,9 @@ resource "databricks_external_location" "external_location_to_add" {
 
 resource "databricks_volume" "add_external_volume_to_schema" {
   provider         = databricks.workspace
-  name             = var.external_volume_name
+  name             = lower(var.external_volume_name)
   catalog_name     = var.databricks_catalog_name
-  schema_name      = var.databricks_schema_name
+  schema_name      = lower(var.databricks_schema_name)
   volume_type      = "EXTERNAL"
   storage_location = "gs://${var.gcs_bucket_name}"
   comment          = var.external_volume_comment

--- a/terraform/modules/dbx_uc_gcs_volume/main.tf
+++ b/terraform/modules/dbx_uc_gcs_volume/main.tf
@@ -24,7 +24,7 @@ resource "google_storage_bucket_iam_member" "SA_legacyBucketOwner_role" {
 
 resource "google_storage_bucket_iam_member" "SA_storageAdmin_role" {
   bucket     = var.gcs_bucket_name
-  role       = "roles/storage.storageAdmin"
+  role       = "roles/storage.admin"
   member     = "serviceAccount:${databricks_storage_credential.create_external_location_creds.databricks_gcp_service_account[0].email}"
   depends_on = [google_storage_bucket_iam_member.SA_legacyBucketOwner_role]
 }

--- a/terraform/modules/dbx_uc_gcs_volume/main.tf
+++ b/terraform/modules/dbx_uc_gcs_volume/main.tf
@@ -15,9 +15,16 @@ resource "google_storage_bucket_object" "empty_folder" {
   bucket  = var.gcs_bucket_name
 }
 
-resource "google_storage_bucket_iam_member" "member" {
+resource "google_storage_bucket_iam_member" "SA_legacyBucketOwner_role" {
   bucket     = var.gcs_bucket_name
   role       = "roles/storage.legacyBucketOwner"
+  member     = "serviceAccount:${databricks_storage_credential.create_external_location_creds.databricks_gcp_service_account[0].email}"
+  depends_on = [google_storage_bucket_object.empty_folder]
+}
+
+resource "google_storage_bucket_iam_member" "SA_storageAdmin_role" {
+  bucket     = var.gcs_bucket_name
+  role       = "roles/storage.storageAdmin"
   member     = "serviceAccount:${databricks_storage_credential.create_external_location_creds.databricks_gcp_service_account[0].email}"
   depends_on = [google_storage_bucket_object.empty_folder]
 }

--- a/terraform/modules/dbx_uc_gcs_volume/main.tf
+++ b/terraform/modules/dbx_uc_gcs_volume/main.tf
@@ -26,7 +26,7 @@ resource "google_storage_bucket_iam_member" "SA_storageAdmin_role" {
   bucket     = var.gcs_bucket_name
   role       = "roles/storage.storageAdmin"
   member     = "serviceAccount:${databricks_storage_credential.create_external_location_creds.databricks_gcp_service_account[0].email}"
-  depends_on = [google_storage_bucket_object.empty_folder]
+  depends_on = [google_storage_bucket_iam_member.SA_legacyBucketOwner_role]
 }
 
 resource "databricks_external_location" "external_location_to_add" {
@@ -35,7 +35,7 @@ resource "databricks_external_location" "external_location_to_add" {
   name            = "gcs-${var.gcs_bucket_name}-${var.external_volume_name}-${local.name_postfix}"
   url             = "gs://${var.gcs_bucket_name}"
   credential_name = databricks_storage_credential.create_external_location_creds.name
-  depends_on      = [google_storage_bucket_iam_member.member]
+  depends_on      = [google_storage_bucket_iam_member.SA_storageAdmin_role]
 }
 
 resource "databricks_volume" "add_external_volume_to_schema" {


### PR DESCRIPTION
As reported in this [issue](https://github.com/databricks/terraform-provider-databricks/issues/2647), there is a problem with the provider that causes weird behavior in the plan against the state file. To solve this, we force all names that are affected by the issue to be lower case.