### PR TITLE
Lag flere jobber basert på schedule_parameters

### DIFF
--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -65,9 +65,10 @@ resource "google_project_iam_member" "token_creator" {
 }
 
 resource "google_cloud_scheduler_job" "invoke_cloud_function" {
+  for_each = { for idx, val in var.schedule_params : idx => val }
   name             = "invoke-${var.name}"
   description      = "Schedule the HTTPS trigger for cloud function"
-  schedule         = var.schedule # every day at midnight
+  schedule         = each.value.schedule
   time_zone        = "Europe/Oslo"
   project          = google_cloudfunctions2_function.this.project
   region           = google_cloudfunctions2_function.this.location
@@ -76,6 +77,11 @@ resource "google_cloud_scheduler_job" "invoke_cloud_function" {
   http_target {
     uri         = google_cloudfunctions2_function.this.service_config[0].uri
     http_method = "POST"
+    body        = base64encode(jsonencode({
+      start_index = each.value.start_index,
+      end_index   = each.value.end_index
+    }))
+
     oidc_token {
       service_account_email = var.service_account_email
     }

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -64,9 +64,13 @@ resource "google_project_iam_member" "token_creator" {
   member  = "serviceAccount:${var.service_account_email}"
 }
 
+locals {
+  job_postfix = length(var.schedule_params) > 1 ? "-${each.key}" : ""
+}
+
 resource "google_cloud_scheduler_job" "invoke_cloud_function" {
   for_each         = {for idx, val in var.schedule_params : idx => val}
-  name             = "invoke-${var.name}-${each.value.start_index}"
+  name             = "invoke-${var.name}${local.job_postfix}"
   description      = "Schedule the HTTPS trigger for cloud function"
   schedule         = each.value.schedule
   time_zone        = "Europe/Oslo"

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -77,10 +77,13 @@ resource "google_cloud_scheduler_job" "invoke_cloud_function" {
   http_target {
     uri         = google_cloudfunctions2_function.this.service_config[0].uri
     http_method = "POST"
-#    body        = base64encode(jsonencode({
-#      start_index = each.value.start_index,
-#      end_index   = each.value.end_index
-#    }))
+    body        = base64encode(jsonencode({
+      start_index = each.value.start_index,
+      end_index   = each.value.end_index
+    }))
+    headers = {
+      "Content-Type" = "application/json"
+    }
 
     oidc_token {
       service_account_email = var.service_account_email

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -65,7 +65,7 @@ resource "google_project_iam_member" "token_creator" {
 }
 
 resource "google_cloud_scheduler_job" "invoke_cloud_function" {
-  for_each = { for idx, val in var.schedule_params : idx => val }
+  for_each         = {for idx, val in var.schedule_params : idx => val}
   name             = "invoke-${var.name}-${each.value.start_index}"
   description      = "Schedule the HTTPS trigger for cloud function"
   schedule         = each.value.schedule
@@ -77,10 +77,10 @@ resource "google_cloud_scheduler_job" "invoke_cloud_function" {
   http_target {
     uri         = google_cloudfunctions2_function.this.service_config[0].uri
     http_method = "POST"
-    body        = base64encode(jsonencode({
-      start_index = each.value.start_index,
-      end_index   = each.value.end_index
-    }))
+#    body        = base64encode(jsonencode({
+#      start_index = each.value.start_index,
+#      end_index   = each.value.end_index
+#    }))
 
     oidc_token {
       service_account_email = var.service_account_email

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -66,7 +66,7 @@ resource "google_project_iam_member" "token_creator" {
 
 resource "google_cloud_scheduler_job" "invoke_cloud_function" {
   for_each = { for idx, val in var.schedule_params : idx => val }
-  name             = "invoke-${var.name}"
+  name             = "invoke-${var.name}-${each.value.start_index}"
   description      = "Schedule the HTTPS trigger for cloud function"
   schedule         = each.value.schedule
   time_zone        = "Europe/Oslo"

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -66,7 +66,7 @@ resource "google_project_iam_member" "token_creator" {
 
 resource "google_cloud_scheduler_job" "invoke_cloud_function" {
   for_each         = { for idx, val in var.schedule_params : idx => val }
-  name             = "invoke-${var.name}${each.value.body.job_postfix}"
+  name             = "invoke-${var.name}${each.value.body != null ? each.value.body.job_postfix : ""}"
   description      = "Schedule the HTTPS trigger for cloud function"
   schedule         = each.value.schedule
   time_zone        = "Europe/Oslo"

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -77,7 +77,7 @@ resource "google_cloud_scheduler_job" "invoke_cloud_function" {
   http_target {
     uri         = google_cloudfunctions2_function.this.service_config[0].uri
     http_method = "POST"
-    body        = base64encode(jsonencode(each.value))
+    body        = base64encode(jsonencode(each.value.body))
     headers = {
       "Content-Type" = "application/json"
     }

--- a/terraform/modules/cloud_function/variables.tf
+++ b/terraform/modules/cloud_function/variables.tf
@@ -106,9 +106,9 @@ variable "schedule_params" {
   type = list(object({
     schedule = string,
     body = optional(object({
-      start_index = optional(number),
-      end_index   = optional(number),
-      job_postfix = optional(string),
+      start_index = number,
+      end_index   = number,
+      job_postfix = string,
   })) }))
 }
 

--- a/terraform/modules/cloud_function/variables.tf
+++ b/terraform/modules/cloud_function/variables.tf
@@ -102,10 +102,6 @@ variable "excludes" {
   ]
 }
 
-variable "schedule" {
-  description = "The cron job schedule for when the cloud function should be triggered. On the format * * * * *. For instance */5 * * * * means every 5th minute. See https://crontab.guru/ for more information."
-}
-
 variable "schedule_params" {}
 
 variable "service_account_email" {}

--- a/terraform/modules/cloud_function/variables.tf
+++ b/terraform/modules/cloud_function/variables.tf
@@ -62,8 +62,8 @@ variable "timeout_seconds" {
 }
 
 variable "available_memory" {
-    description = "(Optional) The amount of memory in megabytes allotted for the function to use. Defaults to 1024M."
-    default     = "1024M"
+  description = "(Optional) The amount of memory in megabytes allotted for the function to use. Defaults to 1024M."
+  default     = "1024M"
 }
 
 variable "environment_variables" {
@@ -102,6 +102,14 @@ variable "excludes" {
   ]
 }
 
-variable "schedule_params" {}
+variable "schedule_params" {
+  type = list(object({
+    schedule = string,
+    body = optional(object({
+      start_index = optional(number),
+      end_index   = optional(number),
+      job_postfix = optional(string),
+  })) }))
+}
 
 variable "service_account_email" {}

--- a/terraform/modules/cloud_function/variables.tf
+++ b/terraform/modules/cloud_function/variables.tf
@@ -106,4 +106,6 @@ variable "schedule" {
   description = "The cron job schedule for when the cloud function should be triggered. On the format * * * * *. For instance */5 * * * * means every 5th minute. See https://crontab.guru/ for more information."
 }
 
+variable "schedule_params" {}
+
 variable "service_account_email" {}

--- a/terraform/modules/dbx_uc_create_catalog/main.tf
+++ b/terraform/modules/dbx_uc_create_catalog/main.tf
@@ -40,8 +40,8 @@ resource "databricks_catalog" "create_team_metastore_catalog" {
 }
 
 resource "databricks_grants" "grants_on_catalog" {
-  catalog   = databricks_catalog.create_team_metastore_catalog.name
-  provider  = databricks.workspace
+  catalog  = databricks_catalog.create_team_metastore_catalog.name
+  provider = databricks.workspace
   grant {
     principal  = var.team_name
     privileges = ["ALL_PRIVILEGES"]


### PR DESCRIPTION
Vi har sett et behov for å lage potensielt flere jobber for én Cloud Function, da uthenting fort tar over 30 min (maks levetid for en jobb). Legger derfor tilrette for at man skal kunne sende med en `scheduler_params`-variabel som krever skeduleringstid + et valgfritt objekt. Per nå ligger `start_index`, `end_index` og `job_postfix` her siden det er det vi trenger for SMIA, men det er mulig vi skal utvide denne ved en senere anledning. 

Dette er en breaking change for de som bruker modulen i dag, så det skal reflekteres i versjoneringen