### PR TITLE
Sett default path til /Repos

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -68,8 +68,9 @@ on:
         default: ""
       databricks_repo_path:
         description: "The path to the repo where the notebooks are located in Databricks."
-        required: true
+        required: false
         type: string
+        default: "/Repos/"
 
 env:
   WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -70,7 +70,7 @@ on:
         description: "The path to the repo where the notebooks are located in Databricks."
         required: false
         type: string
-        default: "/Repos/"
+        default: "/Repos"
 
 env:
   WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}


### PR DESCRIPTION
For at automatisk deploy til miljøene ikke skal brekke, legger jeg inn `/Repos` som default når man forker onboarding-repoet. Konsekvensen er at den potensielt legger seg på rot, men det er bedre enn at hele repoet brekker