### PR TITLE
Bucket retention and Catalog naming

### DIFF
--- a/terraform/iam_module/main.tf
+++ b/terraform/iam_module/main.tf
@@ -16,6 +16,14 @@ resource "google_storage_bucket" "landing_zone_bucket" {
     team    = var.team_name
     purpose = "landing-zone-bucket"
   }
+  lifecycle_rule {
+    condition {
+      age = var.landing_zone_object_retention_days
+    }
+    action {
+      type = "Delete"
+    }
+  }
 }
 
 module "create_uc_catalog" {

--- a/terraform/iam_module/variables.tf
+++ b/terraform/iam_module/variables.tf
@@ -41,6 +41,6 @@ variable "metastore_id" {
 
 variable "landing_zone_object_retention_days" {
   description = "Buckets object retention policy, in days, before deletion"
-  default = 30
-  type = number
+  default     = 30
+  type        = number
 }

--- a/terraform/iam_module/variables.tf
+++ b/terraform/iam_module/variables.tf
@@ -38,3 +38,9 @@ variable "metastore_id" {
   description = "(Required for account-level) Unique identifier of the parent Metastore"
   type        = string
 }
+
+variable "landing_zone_object_retention_days" {
+  description = "Buckets object retention policy, in days, before deletion"
+  default = 30
+  type = number
+}

--- a/terraform/modules/dbx_uc_create_catalog/main.tf
+++ b/terraform/modules/dbx_uc_create_catalog/main.tf
@@ -1,6 +1,6 @@
 locals {
-  name_postfix           = var.env == "prod" ? "" : "-${var.env}"
-  area_short_name_prefix = var.area_short_name == "" ? "" : "${var.area_short_name}-"
+  name_postfix           = var.env == "prod" ? "" : "_${var.env}"
+  area_short_name_prefix = var.area_short_name == "" ? "" : "${var.area_short_name}_"
 }
 
 resource "databricks_storage_credential" "gcs_catalog_bucket_creds" {

--- a/terraform/modules/dbx_uc_create_schema/main.tf
+++ b/terraform/modules/dbx_uc_create_schema/main.tf
@@ -1,5 +1,5 @@
 locals {
-  name_postfix = var.env == "prod" ? "" : "-${var.env}"
+  name_postfix = var.env == "prod" ? "" : "_${var.env}"
 }
 
 resource "databricks_schema" "create_external_schema_in_catalog" {

--- a/terraform/modules/dbx_uc_gcs_volume/main.tf
+++ b/terraform/modules/dbx_uc_gcs_volume/main.tf
@@ -7,6 +7,7 @@ resource "databricks_storage_credential" "create_external_location_creds" {
   name         = "volume-creds-gcs-${var.external_volume_name}${local.name_postfix}"
   metastore_id = var.metastore_id
   databricks_gcp_service_account {}
+  force = true
 }
 
 resource "google_storage_bucket_object" "empty_folder" {

--- a/terraform/modules/dbx_uc_gcs_volume/main.tf
+++ b/terraform/modules/dbx_uc_gcs_volume/main.tf
@@ -32,11 +32,10 @@ resource "google_storage_bucket_iam_member" "SA_storageAdmin_role" {
 resource "databricks_external_location" "external_location_to_add" {
   provider        = databricks.workspace
   metastore_id    = var.metastore_id
-  name            = "gcs-${var.gcs_bucket_name}-${var.external_volume_name}-${local.name_postfix}"
+  name            = "gcs-${var.gcs_bucket_name}-${var.external_volume_name}${local.name_postfix}"
   url             = "gs://${var.gcs_bucket_name}"
   credential_name = databricks_storage_credential.create_external_location_creds.name
   depends_on      = [google_storage_bucket_iam_member.SA_storageAdmin_role]
-  force           = true
 }
 
 resource "databricks_volume" "add_external_volume_to_schema" {

--- a/terraform/modules/dbx_uc_gcs_volume/main.tf
+++ b/terraform/modules/dbx_uc_gcs_volume/main.tf
@@ -7,7 +7,6 @@ resource "databricks_storage_credential" "create_external_location_creds" {
   name         = "volume-creds-gcs-${var.external_volume_name}${local.name_postfix}"
   metastore_id = var.metastore_id
   databricks_gcp_service_account {}
-  force = true
 }
 
 resource "google_storage_bucket_object" "empty_folder" {
@@ -37,6 +36,7 @@ resource "databricks_external_location" "external_location_to_add" {
   url             = "gs://${var.gcs_bucket_name}"
   credential_name = databricks_storage_credential.create_external_location_creds.name
   depends_on      = [google_storage_bucket_iam_member.SA_storageAdmin_role]
+  force           = true
 }
 
 resource "databricks_volume" "add_external_volume_to_schema" {

--- a/terraform/modules/dbx_uc_gcs_volume/outputs.tf
+++ b/terraform/modules/dbx_uc_gcs_volume/outputs.tf
@@ -1,3 +1,3 @@
 output "volume_name" {
-  value       = databricks_volume.add_external_volume_to_schema.name
+  value = databricks_volume.add_external_volume_to_schema.name
 }


### PR DESCRIPTION
Files in the landing zone, should have a given retention policy to avoid the landing zone becoming a swamp for data.

Catalog, schema and table names in unity catalog should have underscore instead of hyphens to avoid having to qoute reference to catalog.schema.table in Unity Catalog.

We need to manually delete external locations in Unity Catalog to be able to change name of catalog and schema. This could be a problem if we decide to enforce a change on naming convention later on.