### PR TITLE
Lag repo hvis det ikke eksisterer, ellers oppdater eksisterende repo

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Create Databricks Repo if it does not exist
         if: env.REPO_EXISTS == 'false'
         run: |
-          databricks repos create $DATABRICKS_WORKSPACE_URL --path ${{ env.DATABRICKS_REPO_PATH }}
+          databricks repos create $DATABRICKS_WORKSPACE_URL --path ${{ env.DATABRICKS_REPO_PATH }} gitHub
       - name: Set Databricks env variables
         run: |
           echo "CREDENTIAL_ID=''" >> $GITHUB_ENV

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -62,6 +62,10 @@ on:
         required: false
         type: string
         default: "/Repos/"
+      repo_url:
+        description: "The url to the repo where the notebooks are located in Databricks."
+        required: true
+        type: string
 
 env:
   WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
@@ -76,6 +80,7 @@ env:
   TF_INIT_OPTION_3: ${{ inputs.terraform_init_option_3 }}
   TF_OPTION_1: ${{ inputs.terraform_option_1 }}
   DATABRICKS_REPO_PATH: ${{ inputs.databricks_repo_path }}
+  REPO_URL: ${{ inputs.repo_url }}
 
 
 jobs:
@@ -168,7 +173,7 @@ jobs:
       - name: Create Databricks Repo if it does not exist
         if: env.REPO_EXISTS == 'false'
         run: |
-          databricks repos create $DATABRICKS_WORKSPACE_URL --path ${{ env.DATABRICKS_REPO_PATH }} gitHub
+          databricks repos create $DATABRICKS_WORKSPACE_URL --path ${{ env.DATABRICKS_REPO_PATH }} gitHub ${{ env.REPO_URL }}
       - name: Set Databricks env variables
         run: |
           echo "CREDENTIAL_ID=''" >> $GITHUB_ENV

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Create Databricks Repo if it does not exist
         if: env.REPO_EXISTS == 'false'
         run: |
-          databricks repos create $DATABRICKS_WORKSPACE_URL --path ${{ env.DATABRICKS_REPO_PATH }} ${{ env.REPO_URL }}
+          databricks repos create ${{ env.REPO_URL }} gitHub --path ${{ env.DATABRICKS_REPO_PATH }}
       - name: Set Databricks env variables
         run: |
           echo "CREDENTIAL_ID=''" >> $GITHUB_ENV

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -153,8 +153,10 @@ jobs:
         run: |
           databricks_host=$(terraform output -raw databricks_host)
           databricks_token=$(terraform output -raw databricks_token)
+          databricks_workspace_url=$(terraform output -raw databricks_workspace_url)
           echo "DATABRICKS_HOST=$databricks_host" >> $GITHUB_ENV
           echo "DATABRICKS_TOKEN=$databricks_token" >> $GITHUB_ENV
+          echo "DATABRICKS_WORKSPACE_URL=$databricks_workspace_url" >> $GITHUB_ENV
       - uses: databricks/setup-cli@main
         name: Setup databricks CLI
       - name: Check if Databricks repo exists
@@ -170,8 +172,7 @@ jobs:
       - name: Create Databricks Repo if it does not exist
         if: env.REPO_EXISTS == 'false'
         run: |
-          # Replace 'YOUR_GITHUB_REPO_URL' with your repository URL
-          databricks repos create --url YOUR_GITHUB_REPO_URL --path $DATABRICKS_REPO_PATH --branch "main"
+          databricks repos create $DATABRICKS_WORKSPACE_URL --path ${{ env.DATABRICKS_REPO_PATH }} --branch "main"
       - name: Set Databricks env variables
         run: |
           echo "CREDENTIAL_ID=''" >> $GITHUB_ENV

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -157,10 +157,8 @@ jobs:
         run: |
           databricks_host=$(terraform output -raw databricks_host)
           databricks_token=$(terraform output -raw databricks_token)
-          databricks_workspace_url=$(terraform output -raw databricks_workspace_url)
           echo "DATABRICKS_HOST=$databricks_host" >> $GITHUB_ENV
           echo "DATABRICKS_TOKEN=$databricks_token" >> $GITHUB_ENV
-          echo "DATABRICKS_WORKSPACE_URL=$databricks_workspace_url" >> $GITHUB_ENV
       - uses: databricks/setup-cli@main
         name: Setup databricks CLI
       - name: Set Databricks env variables

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Create Databricks Repo if it does not exist
         if: env.REPO_EXISTS == 'false'
         run: |
-          databricks repos create $DATABRICKS_WORKSPACE_URL --path ${{ env.DATABRICKS_REPO_PATH }} gitHub ${{ env.REPO_URL }}
+          databricks repos create $DATABRICKS_WORKSPACE_URL --path ${{ env.DATABRICKS_REPO_PATH }} ${{ env.REPO_URL }}
       - name: Set Databricks env variables
         run: |
           echo "CREDENTIAL_ID=''" >> $GITHUB_ENV

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -61,7 +61,7 @@ on:
         description: "The path to the repo where the notebooks are located in Databricks."
         required: false
         type: string
-        default: "/Repos"
+        default: "/Repos/"
 
 env:
   WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
@@ -162,12 +162,8 @@ jobs:
       - name: Check if Databricks repo exists
         run: |
           set +e 
-          REPO_EXISTS=$(databricks repos list --output json | jq -r --arg REPO_PATH "$DATABRICKS_REPO_PATH" '.repos[] | select(.path == $REPO_PATH) | .path')
-          if [ "$REPO_EXISTS" == "$DATABRICKS_REPO_PATH" ]; then
-           echo "REPO_EXISTS=true" >> $GITHUB_ENV
-          else
-           echo "REPO_EXISTS=false" >> $GITHUB_ENV
-          fi
+          REPO_EXISTS=$(databricks repos list --output json | jq -r --arg REPO_PATH "$DATABRICKS_REPO_PATH" 'map(select(.path == $REPO_PATH)) | if length > 0 then "true" else "false" end')
+          echo "REPO_EXISTS=$REPO_EXISTS" >> $GITHUB_ENV
           set -e
       - name: Create Databricks Repo if it does not exist
         if: env.REPO_EXISTS == 'false'

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Create Databricks Repo if it does not exist
         if: env.REPO_EXISTS == 'false'
         run: |
-          databricks repos create $DATABRICKS_WORKSPACE_URL --path ${{ env.DATABRICKS_REPO_PATH }} --branch "main"
+          databricks repos create $DATABRICKS_WORKSPACE_URL --path ${{ env.DATABRICKS_REPO_PATH }} "main"
       - name: Set Databricks env variables
         run: |
           echo "CREDENTIAL_ID=''" >> $GITHUB_ENV

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -59,11 +59,10 @@ on:
         default: false
       databricks_repo_path:
         description: "The path to the repo where the notebooks are located in Databricks."
-        required: false
+        required: true
         type: string
-        default: "/Repos/"
       repo_url:
-        description: "The url to the repo where the notebooks are located in Databricks."
+        description: "The url to the GitHub repository."
         required: true
         type: string
 

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -164,6 +164,15 @@ jobs:
           echo "DATABRICKS_WORKSPACE_URL=$databricks_workspace_url" >> $GITHUB_ENV
       - uses: databricks/setup-cli@main
         name: Setup databricks CLI
+      - name: Set Databricks env variables
+        run: |
+          echo "CREDENTIAL_ID=''" >> $GITHUB_ENV
+      - name: Create git-credentials
+        run: |
+          OUTPUT=$(databricks git-credentials create gitHub --git-username $GITHUB_ACTOR --personal-access-token ${{ secrets.GITHUB_TOKEN }})
+          echo "$OUTPUT"
+          CREDENTIAL_ID=$(echo "$OUTPUT" | jq -r '.credential_id')
+          echo "CREDENTIAL_ID=$CREDENTIAL_ID" >> $GITHUB_ENV
       - name: Check if Databricks repo exists
         run: |
           set +e 
@@ -174,17 +183,8 @@ jobs:
         if: env.REPO_EXISTS == 'false'
         run: |
           databricks repos create ${{ env.REPO_URL }} gitHub --path ${{ env.DATABRICKS_REPO_PATH }}
-      - name: Set Databricks env variables
-        run: |
-          echo "CREDENTIAL_ID=''" >> $GITHUB_ENV
-      - name: Create git-credentials
-        run: |
-          OUTPUT=$(databricks git-credentials create gitHub --git-username $GITHUB_ACTOR --personal-access-token ${{ secrets.GITHUB_TOKEN }})
-          echo "$OUTPUT"
-          CREDENTIAL_ID=$(echo "$OUTPUT" | jq -r '.credential_id')
-          echo "CREDENTIAL_ID=$CREDENTIAL_ID" >> $GITHUB_ENV
       - name: Update Databricks Repo if it exists
-        if: env.CREDENTIAL_ID != ''
+        if: env.REPO_EXISTS == 'true'
         run: |
           databricks repos update ${{ env.DATABRICKS_REPO_PATH }} --branch "main"
       - name: Delete git-credentials

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Check if Databricks repo exists
         run: |
           set +e 
-          REPO_EXISTS=$(databricks repos list --output json | jq -r '.repos[] | select(.path == ${{ env.DATABRICKS_REPO_PATH }}) | .path')
+          REPO_EXISTS=$(databricks repos list --output json | jq -r --arg REPO_PATH "$DATABRICKS_REPO_PATH" '.repos[] | select(.path == $REPO_PATH) | .path')
           if [ "$REPO_EXISTS" == "$DATABRICKS_REPO_PATH" ]; then
            echo "REPO_EXISTS=true" >> $GITHUB_ENV
           else
@@ -172,7 +172,7 @@ jobs:
       - name: Create Databricks Repo if it does not exist
         if: env.REPO_EXISTS == 'false'
         run: |
-          databricks repos create $DATABRICKS_WORKSPACE_URL --path ${{ env.DATABRICKS_REPO_PATH }} "main"
+          databricks repos create $DATABRICKS_WORKSPACE_URL --path ${{ env.DATABRICKS_REPO_PATH }}
       - name: Set Databricks env variables
         run: |
           echo "CREDENTIAL_ID=''" >> $GITHUB_ENV

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -93,7 +93,7 @@ jobs:
           PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
           echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
   deploy_databricks:
-    needs: [setup-env]
+    needs: [ setup-env ]
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.environment }}
@@ -157,6 +157,21 @@ jobs:
           echo "DATABRICKS_TOKEN=$databricks_token" >> $GITHUB_ENV
       - uses: databricks/setup-cli@main
         name: Setup databricks CLI
+      - name: Check if Databricks repo exists
+        run: |
+          set +e 
+          REPO_EXISTS=$(databricks repos list --output json | jq -r '.repos[] | select(.path == ${{ env.DATABRICKS_REPO_PATH }}) | .path')
+          if [ "$REPO_EXISTS" == "$DATABRICKS_REPO_PATH" ]; then
+           echo "REPO_EXISTS=true" >> $GITHUB_ENV
+          else
+           echo "REPO_EXISTS=false" >> $GITHUB_ENV
+          fi
+          set -e
+      - name: Create Databricks Repo if it does not exist
+        if: env.REPO_EXISTS == 'false'
+        run: |
+          # Replace 'YOUR_GITHUB_REPO_URL' with your repository URL
+          databricks repos create --url YOUR_GITHUB_REPO_URL --path $DATABRICKS_REPO_PATH --branch "main"
       - name: Set Databricks env variables
         run: |
           echo "CREDENTIAL_ID=''" >> $GITHUB_ENV
@@ -166,7 +181,7 @@ jobs:
           echo "$OUTPUT"
           CREDENTIAL_ID=$(echo "$OUTPUT" | jq -r '.credential_id')
           echo "CREDENTIAL_ID=$CREDENTIAL_ID" >> $GITHUB_ENV
-      - name: Update Databricks Repo
+      - name: Update Databricks Repo if it exists
         if: env.CREDENTIAL_ID != ''
         run: |
           databricks repos update ${{ env.DATABRICKS_REPO_PATH }} --branch "main"


### PR DESCRIPTION
Frem til nå har det bare vært mulig å oppdatere et repo som allerede eksisterer i Databricks. Dette har gjort at produktteamene har måttet legge disse inn manuelt, noe som er unødvendig da det burde opprettes fra workflowen. 

Med denne endringen blir det opprettet et repository under `/Repos/<team-navn>/<repo-navn>`. Mappen i team-navnet blir laget automatisk i dask-infrastructure. De to tingene produktteam nå må gjøre i sin egen GitHub workflow er å:
- Spesifisere `databricks_repo_path` (eksempelvis `Repos/smia/smia-data-ingestor`)
- Spesifisere `repo_url` (eksempelvis `https://github.com/kartverket/smia-data-ingestor.git`)