### PR TITLE
Ignorer endringer i generation på Cloud Functions

### DIFF
--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -18,6 +18,8 @@ resource "google_cloudfunctions2_function" "this" {
   project     = var.project
   labels      = var.labels
 
+  lifecycle { ignore_changes = [build_config[0].source[0].storage_source[0].generation] }
+
   build_config {
     runtime     = var.runtime
     entry_point = var.entry_point


### PR DESCRIPTION
Det er en [bug i Google-provideren](https://github.com/hashicorp/terraform-provider-google/issues/15249) som gjør at alle Cloud Functions prøver å oppdatere seg selv om ingen endringer er skjedd. Ignorerer derfor endringene som skjer i `generation`, så tar det mye kortere tid å deploye endringer