### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 2.0

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: IT
+version: 2.0
+organization: IT
+product: Dataplattformtjenester
+repo_types: [Library,Ops]
+platforms: []


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 2.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 2.0`
- `organization: IT`
- `product: Dataplattformtjenester`
- `repo_types: [Library,Ops]`
- `platforms: []`

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.