### PR TITLE
Bare oppdater Databricks-repo automatisk i produksjon

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -181,7 +181,7 @@ jobs:
         run: |
           databricks repos create ${{ env.REPO_URL }} gitHub --path ${{ env.DATABRICKS_REPO_PATH }}
       - name: Update Databricks Repo if it exists
-        if: env.REPO_EXISTS == 'true'
+        if: env.REPO_EXISTS == 'true' && env.ENVIRONMENT == 'prod'
         run: |
           databricks repos update ${{ env.DATABRICKS_REPO_PATH }} --branch "main"
       - name: Delete git-credentials


### PR DESCRIPTION
Det er viktig å holde repoet i Databricks oppdatert i produksjon, spesielt da vi er nødt til å lage jobbene med lokal sti mot repoet fordi deploy-kontoene ikke har tilgang til GitHub. Det er derimot ikke like nødvendig i dev og test, og det er mer forstyrrende at arbeid man gjør overskrives med main-branch under utvikling. 

Setter derfor opp et ekstra flagg som kun oppdaterer repoet til main i prod.