### PR TITLE
Legg inn variabel for å oppdatere repo eller ikke på DBX

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -65,6 +65,11 @@ on:
         description: "The url to the GitHub repository."
         required: true
         type: string
+      should_update_databricks:
+        description: "An optional boolean which updates the Databricks repo when set to true. Defaults to false"
+        required: false
+        type: boolean
+        default: false
 
 env:
   WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
@@ -80,6 +85,7 @@ env:
   TF_OPTION_1: ${{ inputs.terraform_option_1 }}
   DATABRICKS_REPO_PATH: ${{ inputs.databricks_repo_path }}
   REPO_URL: ${{ inputs.repo_url }}
+  SHOULD_UPDATE_DATABRICKS: ${{ inputs.should_update_databricks }}
 
 
 jobs:
@@ -181,7 +187,7 @@ jobs:
         run: |
           databricks repos create ${{ env.REPO_URL }} gitHub --path ${{ env.DATABRICKS_REPO_PATH }}
       - name: Update Databricks Repo if it exists
-        if: env.REPO_EXISTS == 'true'
+        if: env.REPO_EXISTS == 'true' && env.SHOULD_UPDATE_DATABRICKS == 'true'
         run: |
           databricks repos update ${{ env.DATABRICKS_REPO_PATH }} --branch "main"
       - name: Delete git-credentials


### PR DESCRIPTION
For å unngå at pipelines kræsjer under merge når andre jobber i notebooks i Databricks, så legger jeg inn et flagg som bestemmer om workflowen skal pushe automatisk til miljøet eller ikke. 

Tanken er at denne i utgangspunktet bare skal stå på for prod (kanskje test), mens i dev skal den være `false`