### PR TITLE
Lag modul for service account som kan kjøre jobber

### DIFF
--- a/terraform/modules/job_service_account/backend.tf
+++ b/terraform/modules/job_service_account/backend.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    databricks = {
+      source                = "databricks/databricks"
+      configuration_aliases = [databricks.workspace]
+    }
+  }
+}

--- a/terraform/modules/job_service_account/main.tf
+++ b/terraform/modules/job_service_account/main.tf
@@ -1,3 +1,7 @@
+# Module for creating a service account for running Databricks jobs.
+# Add the service account as an "external user" in dask-infrastructure to get necessary Databricks access:
+# https://github.com/kartverket/dask-infrastructure/blob/main/terraform/modules/product_teams/main.tf#L11
+
 resource "google_service_account" "dbx_job_runner" {
   account_id   = "databricks-job-runner"
   display_name = "My Service Account"

--- a/terraform/modules/job_service_account/main.tf
+++ b/terraform/modules/job_service_account/main.tf
@@ -34,6 +34,7 @@ resource "google_storage_bucket_iam_member" "catalog_object_admin" {
 
 # Service account access to product team catalog
 resource "databricks_grant" "catalog_grant" {
+  provider   = databricks.workspace
   principal  = google_service_account.dbx_job_runner.email
   privileges = ["ALL_PRIVILEGES"]
   catalog    = var.catalog_name

--- a/terraform/modules/job_service_account/main.tf
+++ b/terraform/modules/job_service_account/main.tf
@@ -1,0 +1,36 @@
+resource "google_service_account" "dbx_job_runner" {
+  account_id   = "databricks-job-runner"
+  display_name = "My Service Account"
+}
+
+# Service account GCP access for landing zone and catalog buckets
+resource "google_storage_bucket_iam_member" "lz_legacy_bucket_reader" {
+  bucket = "landing-zone-${var.project_id}"
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.dbx_job_runner.email}"
+}
+
+resource "google_storage_bucket_iam_member" "lz_object_admin" {
+  bucket = "landing-zone-${var.project_id}"
+  member = "serviceAccount:${google_service_account.dbx_job_runner.email}"
+  role   = "roles/storage.objectAdmin"
+}
+
+resource "google_storage_bucket_iam_member" "catalog_legacy_bucket_reader" {
+  bucket = "catalog-${var.project_id}"
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.dbx_job_runner.email}"
+}
+
+resource "google_storage_bucket_iam_member" "catalog_object_admin" {
+  bucket = "catalog-${var.project_id}"
+  member = "serviceAccount:${google_service_account.dbx_job_runner.email}"
+  role   = "roles/storage.objectAdmin"
+}
+
+# Service account access to product team catalog
+resource "databricks_grant" "catalog_grant" {
+  principal  = google_service_account.dbx_job_runner.email
+  privileges = ["ALL_PRIVILEGES"]
+  catalog    = var.catalog_name
+}

--- a/terraform/modules/job_service_account/outputs.tf
+++ b/terraform/modules/job_service_account/outputs.tf
@@ -1,0 +1,3 @@
+output "service_account_email" {
+  value = google_service_account.dbx_job_runner.email
+}

--- a/terraform/modules/job_service_account/variables.tf
+++ b/terraform/modules/job_service_account/variables.tf
@@ -1,0 +1,9 @@
+variable "project_id" {
+  description = "The project ID to the product team's GCP project"
+  type        = string
+}
+
+variable "catalog_name" {
+  description = "The name of the product team's catalog"
+  type        = string
+}


### PR DESCRIPTION
Vi ønsker å redusere mengden tilganger deploy-kontoen til produktteamene har på plattformen. Første steg i den retningen er å bruke en egen service account som kan kjøre jobber. Lager en modul der SA-en blir opprettet, samt tilganger til relevante bøtter og produktteamets katalog i Databricks.

**NB:** Man er fortsatt nødt til å legge SA-en inn i dask-infra for tilganger til cluster, repo-område, etc.