### PR TITLE
Lag workflow for å opprette og populere repo i onboardingsfasen for produktteam

### DIFF
--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -1,0 +1,32 @@
+name: Create empty GitHub repo and clone monorepo into it
+
+on:
+  workflow_call:
+    inputs:
+      repo_name:
+        description: "The name of the repository to create"
+        required: true
+        type: string
+
+env:
+  GITHUB_TOKEN: ${{ secrets.DASK_ONBOARDING_PAT }}
+  REPO_NAME: ${{ inputs.repo_name }}
+
+
+jobs:
+  setup_env:
+      runs-on: ubuntu-latest
+  create_and_clone_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create empty repo
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+          script: |
+            const repo = await github.repos.createForAuthenticatedUser({
+              name: env.REPO_NAME,
+              visibility: internal
+            });
+            console.log(repo.data.clone_url);
+

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -26,7 +26,6 @@ jobs:
                 org: 'Kartverket',
                 name: '${{ env.REPO_NAME }}',
                 description: 'This is your first repository',
-                homepage: 'https://github.com',
                 visibility: 'internal',
                 headers: {
                   'X-GitHub-Api-Version': '2022-11-28'

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -17,27 +17,27 @@ jobs:
   create_and_clone_repo:
     runs-on: ubuntu-latest
     steps:
-#      - name: Create empty repo
-#        uses: actions/github-script@v7
-#        with:
-#          github-token: ${{ env.GITHUB_TOKEN }}
-#          script: |
-#            const repoName = '${{ env.REPO_NAME }}';
-#            const response = await github.request('POST /orgs/{org}/repos', {
-#                org: 'kartverket',
-#                name: '${{ env.REPO_NAME }}',
-#                description: 'This is your first repository',
-#                visibility: 'internal',
-#                headers: {
-#                  'X-GitHub-Api-Version': '2022-11-28'
-#                }
-#            });
-#            console.log(`Response for creating repo ${repoName}:`, response);
+      - name: Create empty repo
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+          script: |
+            const repoName = '${{ env.REPO_NAME }}';
+            const response = await github.request('POST /orgs/{org}/repos', {
+                org: 'kartverket',
+                name: '${{ env.REPO_NAME }}',
+                description: 'This is your first repository',
+                visibility: 'public',
+                headers: {
+                  'X-GitHub-Api-Version': '2022-11-28'
+                }
+            });
+            console.log(`Response for creating repo ${repoName}:`, response);
       - name: Checkout the reference repository
         uses: actions/checkout@v4
         with:
           repository: kartverket/dask-monorepo-reference-setup
-          path: 'cloned-repo'
+          path: ${{ env.REPO_NAME }}
 
       - name: Initialize new repository and push
         run: |

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -24,9 +24,19 @@ jobs:
         with:
           github-token: ${{ env.GITHUB_TOKEN }}
           script: |
-            const repo = await github.repos.createForAuthenticatedUser({
-              name: env.REPO_NAME,
-              visibility: internal
-            });
-            console.log(repo.data.clone_url);
+            const octokit = new Octokit({
+              auth: 'YOUR-TOKEN'
+            })
+              
+            await octokit.request('POST /orgs/{org}/repos', {
+              org: 'Kartverket',
+              name: '${{ env.REPO_NAME }}',
+              description: 'This is your first repository',
+              homepage: 'https://github.com',
+              'visibility': 'internal',
+              headers: {
+                'X-GitHub-Api-Version': '2022-11-28'
+             }
+            })
+
 

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -47,6 +47,7 @@ jobs:
           git config --global user.name "DASK CI"
           git config --global user.email "noreply@kartverket.no"
           git checkout -b clone-monorepo
+          git remote remove origin
           git remote set-url origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
           echo "git status: $(git status)"
           echo "git push"

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           cd cloned-repo
           git init
+          git config --global user.name "DASK CI"
+          git config --global user.email "noreply@kartverket.no"
           git add .
           git commit -m "Initial commit from reference repository"
           git branch -M main  

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -47,7 +47,8 @@ jobs:
           git config --global user.email "noreply@kartverket.no"
           git remote rename origin old-origin
           echo "git remote add"
-          git remote add origin https://x-access-token:${{ env.GITHUB_TOKEN }}@github.com/kartverket/${{ env.REPO_NAME }}.git
+          git remote add origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
+          echo "git push"
           git push -u origin --all
           git push -u origin --tags
 

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -22,19 +22,15 @@ jobs:
         with:
           github-token: ${{ env.GITHUB_TOKEN }}
           script: |
-            const octokit = new Octokit({
-              auth: '${{ env.GITHUB_TOKEN }}'
-            })
-              
-            await octokit.request('POST /orgs/{org}/repos', {
-              org: 'Kartverket',
-              name: '${{ env.REPO_NAME }}',
-              description: 'This is your first repository',
-              homepage: 'https://github.com',
-              'visibility': 'internal',
-              headers: {
-                'X-GitHub-Api-Version': '2022-11-28'
-             }
+            await github.request('POST /orgs/{org}/repos', {
+                org: 'Kartverket',
+                name: '${{ env.REPO_NAME }}',
+                description: 'This is your first repository',
+                homepage: 'https://github.com',
+                visibility: 'internal',
+                headers: {
+                  'X-GitHub-Api-Version': '2022-11-28'
+                }
             })
 
 

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -41,13 +41,13 @@ jobs:
 
       - name: Push to a new branch
         env:
-          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd cloned-repo
           git config user.name "DASK CI"
           git config user.email "noreply@kartverket.no"
           git checkout -b clone-monorepo
-          git remote set-url origin https://x-access-token:${MY_GITHUB_PAT}@github.com/kartverket/${{ env.REPO_NAME }}.git
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/kartverket/${{ env.REPO_NAME }}.git
           git push -u origin clone-monorepo
 
       - name: Create pull request

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -14,8 +14,6 @@ env:
 
 
 jobs:
-  setup_env:
-      runs-on: ubuntu-latest
   create_and_clone_repo:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -33,21 +33,22 @@ jobs:
 #                }
 #            });
 #            console.log(`Response for creating repo ${repoName}:`, response);
-      - name: Checkout the reference repository
-        uses: actions/checkout@v4
-        with:
-          repository: kartverket/dask-monorepo-reference-setup
-          path: 'cloned-repo'
+#      - name: Checkout the reference repository
+#        uses: actions/checkout@v4
+#        with:
+#          repository: kartverket/dask-monorepo-reference-setup
+#          path: 'cloned-repo'
 
       - name: Push to a new branch
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: |
-          cd cloned-repo
+          git clone https://github.com/kartverket/kartverket/dask-monorepo-reference-setup.git
+          cd dask-monorepo-reference-setup
           git config user.name "DASK CI"
           git config user.email "noreply@kartverket.no"
           git checkout -b clone-monorepo
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/kartverket/${{ env.REPO_NAME }}.git
+          git remote set-url origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
           echo "git push"
           git push -u origin clone-monorepo
 

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -42,13 +42,12 @@ jobs:
       - name: Initialize new repository and push
         run: |
           cd cloned-repo
-          echo "git init"
           git init
           git config --global user.name "DASK CI"
           git config --global user.email "noreply@kartverket.no"
           git remote rename origin old-origin
           echo "git remote add"
-          git remote add origin https://x-access-token:${{ env.GITHUB_TOKEN }}@https://github.com/kartverket/${{ env.REPO_NAME }}.git
+          git remote add origin https://x-access-token:${{ env.GITHUB_TOKEN }}@github.com/kartverket/${{ env.REPO_NAME }}.git
           git push -u origin --all
           git push -u origin --tags
 

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -41,8 +41,6 @@ jobs:
           token: ${{ env.GITHUB_TOKEN }}
 
       - name: Push to a new branch
-        env:
-          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: |
           git config --global user.name "DASK CI"
           git config --global user.email "noreply@kartverket.no"
@@ -51,7 +49,7 @@ jobs:
           git add .
           git commit -m "Initial commit"
           git branch -M main
-          git remote add origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
+          git remote add origin https://x-access-token:${{env.GITHUB_TOKEN}}@github.com/kartverket/${{ env.REPO_NAME }}.git
           echo "git status: $(git status)"
           echo "git push"
           git push -u origin main

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -22,7 +22,8 @@ jobs:
         with:
           github-token: ${{ env.GITHUB_TOKEN }}
           script: |
-            await github.request('POST /orgs/{org}/repos', {
+            const repoName = '${{ env.REPO_NAME }}';
+            const response = await github.request('POST /orgs/{org}/repos', {
                 org: 'kartverket',
                 name: '${{ env.REPO_NAME }}',
                 description: 'This is your first repository',
@@ -30,8 +31,8 @@ jobs:
                 headers: {
                   'X-GitHub-Api-Version': '2022-11-28'
                 }
-            })
-            echo "Repository created"
+            });
+            console.log(`Response for creating repo ${repoName}:`, response);
       - name: Checkout the reference repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -23,7 +23,7 @@ jobs:
           github-token: ${{ env.GITHUB_TOKEN }}
           script: |
             await github.request('POST /orgs/{org}/repos', {
-                org: 'Kartverket',
+                org: 'kartverket',
                 name: '${{ env.REPO_NAME }}',
                 description: 'This is your first repository',
                 visibility: 'internal',
@@ -31,5 +31,20 @@ jobs:
                   'X-GitHub-Api-Version': '2022-11-28'
                 }
             })
+            echo "Repository created"
+      - name: Checkout the reference repository
+        uses: actions/checkout@v4
+        with:
+          repository: kartverket/dask-monorepo-reference-setup
+          path: 'cloned-repo'
+
+      - name: Initialize new repository and push
+        run: |
+          cd cloned-repo
+          git init
+          git add .
+          git commit -m "Initial commit from reference repository"
+          git remote add origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
+          git push -u origin main
 
 

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -42,11 +42,13 @@ jobs:
       - name: Initialize new repository and push
         run: |
           cd cloned-repo
+          echo "git init"
           git init
           git config --global user.name "DASK CI"
           git config --global user.email "noreply@kartverket.no"
           git remote rename origin old-origin
-          git remote add origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
+          echo "git remote add"
+          git remote add origin https://x-access-token:${{ env.GITHUB_TOKEN }}@https://github.com/kartverket/${{ env.REPO_NAME }}.git
           git push -u origin --all
           git push -u origin --tags
 

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -27,7 +27,7 @@ jobs:
                 org: 'kartverket',
                 name: '${{ env.REPO_NAME }}',
                 description: 'This is your first repository',
-                visibility: 'public',
+                visibility: 'internal',
                 headers: {
                   'X-GitHub-Api-Version': '2022-11-28'
                 }

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -25,7 +25,7 @@ jobs:
           github-token: ${{ env.GITHUB_TOKEN }}
           script: |
             const octokit = new Octokit({
-              auth: 'YOUR-TOKEN'
+              auth: '${{ env.GITHUB_TOKEN }}'
             })
               
             await octokit.request('POST /orgs/{org}/repos', {

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: |
-          git clone https://github.com/kartverket/kartverket/dask-monorepo-reference-setup.git
+          git clone https://github.com/kartverket/dask-monorepo-reference-setup.git
           cd dask-monorepo-reference-setup
           git config user.name "DASK CI"
           git config user.email "noreply@kartverket.no"

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -49,11 +49,12 @@ jobs:
           rm -rf .git
           git init
           git add .
-          git checkout -b clone-monorepo
-          git remote set-url origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
+          git commit -m "Initial commit"
+          git branch -M main
+          git remote add origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
           echo "git status: $(git status)"
           echo "git push"
-          git push -u origin clone-monorepo
+          git push -u origin main
 
       - name: Create pull request
         uses: actions/github-script@v7

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -17,22 +17,22 @@ jobs:
   create_and_clone_repo:
     runs-on: ubuntu-latest
     steps:
-      - name: Create empty repo
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ env.GITHUB_TOKEN }}
-          script: |
-            const repoName = '${{ env.REPO_NAME }}';
-            const response = await github.request('POST /orgs/{org}/repos', {
-                org: 'kartverket',
-                name: '${{ env.REPO_NAME }}',
-                description: 'This is your first repository',
-                visibility: 'internal',
-                headers: {
-                  'X-GitHub-Api-Version': '2022-11-28'
-                }
-            });
-            console.log(`Response for creating repo ${repoName}:`, response);
+#      - name: Create empty repo
+#        uses: actions/github-script@v7
+#        with:
+#          github-token: ${{ env.GITHUB_TOKEN }}
+#          script: |
+#            const repoName = '${{ env.REPO_NAME }}';
+#            const response = await github.request('POST /orgs/{org}/repos', {
+#                org: 'kartverket',
+#                name: '${{ env.REPO_NAME }}',
+#                description: 'This is your first repository',
+#                visibility: 'internal',
+#                headers: {
+#                  'X-GitHub-Api-Version': '2022-11-28'
+#                }
+#            });
+#            console.log(`Response for creating repo ${repoName}:`, response);
       - name: Checkout the reference repository
         uses: actions/checkout@v4
         with:
@@ -45,10 +45,9 @@ jobs:
           git init
           git config --global user.name "DASK CI"
           git config --global user.email "noreply@kartverket.no"
-          git add .
-          git commit -m "Initial commit from reference repository"
-          git branch -M main  
+          git remote rename origin old-origin
           git remote add origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
-          git push -u origin main
+          git push -u origin --all
+          git push -u origin --tags
 
 

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Push to a new branch
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: |
           cd cloned-repo
           git config user.name "DASK CI"

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -39,17 +39,32 @@ jobs:
           repository: kartverket/dask-monorepo-reference-setup
           path: 'cloned-repo'
 
-      - name: Initialize new repository and push
+      - name: Push to a new branch
         run: |
           cd cloned-repo
-          git init
-          git config --global user.name "DASK CI"
-          git config --global user.email "noreply@kartverket.no"
-          git remote rename origin old-origin
-          echo "git remote add"
+          git config user.name "DASK CI"
+          git config user.email "noreply@kartverket.no"
+          git checkout -b clone-monorepo
+          git add .
+          git commit -m "Cloning monorepo from kartverket/dask-monorepo-reference-setup"
           git remote add origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
-          echo "git push"
-          git push -u origin --all
-          git push -u origin --tags
+          git push -u origin clone-monorepo
 
-
+      - name: Create pull request
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+          script: |
+            const repoName = ${{ env.REPO_NAME }};
+            const owner = 'kartverket';
+            const head = 'clone-monorepo'; 
+            const base = 'main';
+            const title = 'Clone monorepo reference setup into new repository';
+            
+            await github.rest.pulls.create({
+              owner,
+              repo: repoName,
+              title,
+              head,
+              base,
+            });

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -45,7 +45,7 @@ jobs:
           git config user.name "DASK CI"
           git config user.email "noreply@kartverket.no"
           git checkout -b clone-monorepo
-          git remote add origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
+          git remote set-url origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
           git push -u origin clone-monorepo
 
       - name: Create pull request

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -17,22 +17,22 @@ jobs:
   create_and_clone_repo:
     runs-on: ubuntu-latest
     steps:
-#      - name: Create empty repo
-#        uses: actions/github-script@v7
-#        with:
-#          github-token: ${{ env.GITHUB_TOKEN }}
-#          script: |
-#            const repoName = '${{ env.REPO_NAME }}';
-#            const response = await github.request('POST /orgs/{org}/repos', {
-#                org: 'kartverket',
-#                name: '${{ env.REPO_NAME }}',
-#                description: 'This is your first repository',
-#                visibility: 'public',
-#                headers: {
-#                  'X-GitHub-Api-Version': '2022-11-28'
-#                }
-#            });
-#            console.log(`Response for creating repo ${repoName}:`, response);
+      - name: Create empty repo
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+          script: |
+            const repoName = '${{ env.REPO_NAME }}';
+            const response = await github.request('POST /orgs/{org}/repos', {
+                org: 'kartverket',
+                name: '${{ env.REPO_NAME }}',
+                description: 'This is your first repository',
+                visibility: 'public',
+                headers: {
+                  'X-GitHub-Api-Version': '2022-11-28'
+                }
+            });
+            console.log(`Response for creating repo ${repoName}:`, response);
       - name: Checkout the reference repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -45,8 +45,6 @@ jobs:
           git config user.name "DASK CI"
           git config user.email "noreply@kartverket.no"
           git checkout -b clone-monorepo
-          git add .
-          git commit -m "Cloning monorepo from kartverket/dask-monorepo-reference-setup"
           git remote add origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
           git push -u origin clone-monorepo
 

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -1,7 +1,7 @@
 name: Create empty GitHub repo and clone monorepo into it
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       repo_name:
         description: "The name of the repository to create"

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -45,6 +45,7 @@ jobs:
           git init
           git add .
           git commit -m "Initial commit from reference repository"
+          git branch -M main  
           git remote add origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
           git push -u origin main
 

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -48,6 +48,7 @@ jobs:
           git config user.email "noreply@kartverket.no"
           git checkout -b clone-monorepo
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/kartverket/${{ env.REPO_NAME }}.git
+          echo "git push"
           git push -u origin clone-monorepo
 
       - name: Create pull request

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -49,6 +49,7 @@ jobs:
           git config --global user.email "noreply@kartverket.no"
           git checkout -b clone-monorepo
           git remote set-url origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
+          echo "git status: $(git status)"
           echo "git push"
           git push -u origin clone-monorepo
 

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -54,21 +54,3 @@ jobs:
           echo "git push"
           git push -u origin main
 
-      - name: Create pull request
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ env.GITHUB_TOKEN }}
-          script: |
-            const repoName = ${{ env.REPO_NAME }};
-            const owner = 'kartverket';
-            const head = 'clone-monorepo'; 
-            const base = 'main';
-            const title = 'Clone monorepo reference setup into new repository';
-            
-            await github.rest.pulls.create({
-              owner,
-              repo: repoName,
-              title,
-              head,
-              base,
-            });

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -46,8 +46,10 @@ jobs:
         run: |
           git config --global user.name "DASK CI"
           git config --global user.email "noreply@kartverket.no"
+          rm -rf .git
+          git init
+          git add .
           git checkout -b clone-monorepo
-          git remote remove origin
           git remote set-url origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
           echo "git status: $(git status)"
           echo "git push"

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -33,20 +33,20 @@ jobs:
 #                }
 #            });
 #            console.log(`Response for creating repo ${repoName}:`, response);
-#      - name: Checkout the reference repository
-#        uses: actions/checkout@v4
-#        with:
-#          repository: kartverket/dask-monorepo-reference-setup
-#          path: 'cloned-repo'
+      - name: Checkout the reference repository
+        uses: actions/checkout@v4
+        with:
+          repository: kartverket/dask-monorepo-reference-setup
+          path: 'cloned-repo'
+          token: ${{ env.GITHUB_TOKEN }}
 
       - name: Push to a new branch
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: |
-          git clone https://github.com/kartverket/dask-monorepo-reference-setup.git
-          cd dask-monorepo-reference-setup
-          git config user.name "DASK CI"
-          git config user.email "noreply@kartverket.no"
+          cd cloned-repo
+          git config --global user.name "DASK CI"
+          git config --global user.email "noreply@kartverket.no"
           git checkout -b clone-monorepo
           git remote set-url origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
           echo "git push"

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -37,14 +37,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kartverket/dask-monorepo-reference-setup
-          path: 'cloned-repo'
+          ref: main
           token: ${{ env.GITHUB_TOKEN }}
 
       - name: Push to a new branch
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: |
-          cd cloned-repo
           git config --global user.name "DASK CI"
           git config --global user.email "noreply@kartverket.no"
           git checkout -b clone-monorepo

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -40,12 +40,14 @@ jobs:
           path: 'cloned-repo'
 
       - name: Push to a new branch
+        env:
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: |
           cd cloned-repo
           git config user.name "DASK CI"
           git config user.email "noreply@kartverket.no"
           git checkout -b clone-monorepo
-          git remote set-url origin https://github.com/kartverket/${{ env.REPO_NAME }}.git
+          git remote set-url origin https://x-access-token:${MY_GITHUB_PAT}@github.com/kartverket/${{ env.REPO_NAME }}.git
           git push -u origin clone-monorepo
 
       - name: Create pull request

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -17,27 +17,27 @@ jobs:
   create_and_clone_repo:
     runs-on: ubuntu-latest
     steps:
-      - name: Create empty repo
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ env.GITHUB_TOKEN }}
-          script: |
-            const repoName = '${{ env.REPO_NAME }}';
-            const response = await github.request('POST /orgs/{org}/repos', {
-                org: 'kartverket',
-                name: '${{ env.REPO_NAME }}',
-                description: 'This is your first repository',
-                visibility: 'public',
-                headers: {
-                  'X-GitHub-Api-Version': '2022-11-28'
-                }
-            });
-            console.log(`Response for creating repo ${repoName}:`, response);
+#      - name: Create empty repo
+#        uses: actions/github-script@v7
+#        with:
+#          github-token: ${{ env.GITHUB_TOKEN }}
+#          script: |
+#            const repoName = '${{ env.REPO_NAME }}';
+#            const response = await github.request('POST /orgs/{org}/repos', {
+#                org: 'kartverket',
+#                name: '${{ env.REPO_NAME }}',
+#                description: 'This is your first repository',
+#                visibility: 'public',
+#                headers: {
+#                  'X-GitHub-Api-Version': '2022-11-28'
+#                }
+#            });
+#            console.log(`Response for creating repo ${repoName}:`, response);
       - name: Checkout the reference repository
         uses: actions/checkout@v4
         with:
           repository: kartverket/dask-monorepo-reference-setup
-          path: ${{ env.REPO_NAME }}
+          path: 'cloned-repo'
 
       - name: Initialize new repository and push
         run: |


### PR DESCRIPTION
Som første steg i onboardingen på DASK trenger vi å lage et tomt repo og populere dette med eksempel-kode fra `monorepo-reference-setup`. Setter opp en action som først oppretter et internt repo for teamet med et navn som de selv forer inn. Deretter kloner vi inn monorepoet og pusher det til det nye repoet. 

Bruker en fine-grained PAT som jeg har generert. Ligger i Secret Manager under `dask-onboarding-token` i dataplattform-prod-prosjektet