### PR TITLE
Modul for oppsett av tilbyder på Skyporten

### DIFF
--- a/terraform/modules/skyporten_workload_identity/backend.tf
+++ b/terraform/modules/skyporten_workload_identity/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}

--- a/terraform/modules/skyporten_workload_identity/main.tf
+++ b/terraform/modules/skyporten_workload_identity/main.tf
@@ -1,0 +1,38 @@
+# Set up the IAM workload identity pool and provider for Skyporten integration
+resource "google_iam_workload_identity_pool" "maskinporten_test" {
+  workload_identity_pool_id = var.workload_pool_id
+  display_name              = var.workload_pool_id
+}
+
+resource "google_iam_workload_identity_pool_provider" "maskinporten" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.maskinporten_test.workload_identity_pool_id
+  workload_identity_pool_provider_id = var.provider_id
+  attribute_mapping = {
+    "attribute.maskinportenscope" = "assertion.scope"
+    "google.subject"              = "assertion.consumer.ID"
+    "attribute.clientaccess"      = "\"client::\" + assertion.consumer.ID + \"::\" + assertion.scope"
+  }
+  display_name = "Test admin enheter provider"
+  description  = "OIDC identity pool provider for Maskinporten"
+  oidc {
+    allowed_audiences = [var.required_audience]
+    issuer_uri        = "https://test.sky.maskinporten.no"
+  }
+}
+
+# Define consumers and access levels
+module "skyporten_consumer" {
+  source   = "./skyporten_consumers"
+  for_each = var.org_numbers
+
+  maskinporten_scope     = var.maskinporten_scope
+  maskinporten_client_id = "0192:${each.value}"
+  region                 = var.region
+  org_number             = each.value
+  project_number         = var.project_number
+
+  workload_identity_pool_id = google_iam_workload_identity_pool.maskinporten_test.workload_identity_pool_id
+  providers = {
+    google = google
+  }
+}

--- a/terraform/modules/skyporten_workload_identity/main.tf
+++ b/terraform/modules/skyporten_workload_identity/main.tf
@@ -12,7 +12,7 @@ resource "google_iam_workload_identity_pool_provider" "maskinporten" {
     "google.subject"              = "assertion.consumer.ID"
     "attribute.clientaccess"      = "\"client::\" + assertion.consumer.ID + \"::\" + assertion.scope"
   }
-  display_name = var.display_name
+  display_name = var.workload_identity_pool_display_name
   description  = "OIDC identity pool provider for Maskinporten"
   oidc {
     allowed_audiences = [var.required_audience]
@@ -25,9 +25,10 @@ module "skyporten_consumer" {
   source   = "./skyporten_consumers"
   for_each = var.consumer_org_numbers
 
-  maskinporten_scope = var.maskinporten_scope
   # 0192 is the prefix for Norwegian organizations
   maskinporten_client_id    = "0192:${each.key}"
+  main_scope                = var.main_scope
+  sub_scope                 = var.sub_scope
   region                    = var.region
   org_number                = each.key
   consumer_name             = each.value

--- a/terraform/modules/skyporten_workload_identity/main.tf
+++ b/terraform/modules/skyporten_workload_identity/main.tf
@@ -12,11 +12,11 @@ resource "google_iam_workload_identity_pool_provider" "maskinporten" {
     "google.subject"              = "assertion.consumer.ID"
     "attribute.clientaccess"      = "\"client::\" + assertion.consumer.ID + \"::\" + assertion.scope"
   }
-  display_name = "Test admin enheter provider"
+  display_name = var.display_name
   description  = "OIDC identity pool provider for Maskinporten"
   oidc {
     allowed_audiences = [var.required_audience]
-    issuer_uri        = "https://test.sky.maskinporten.no"
+    issuer_uri        = var.issuer_uri
   }
 }
 
@@ -25,10 +25,12 @@ module "skyporten_consumer" {
   source   = "./skyporten_consumers"
   for_each = var.consumer_org_numbers
 
-  maskinporten_scope        = var.maskinporten_scope
-  maskinporten_client_id    = "0192:${each.value}"
+  maskinporten_scope = var.maskinporten_scope
+  # 0192 is the prefix for Norwegian organizations
+  maskinporten_client_id    = "0192:${each.key}"
   region                    = var.region
-  org_number                = each.value
+  org_number                = each.key
+  consumer_name             = each.value
   project_number            = var.project_number
   workload_identity_pool_id = google_iam_workload_identity_pool.maskinporten.workload_identity_pool_id
   project_id                = var.project_id

--- a/terraform/modules/skyporten_workload_identity/main.tf
+++ b/terraform/modules/skyporten_workload_identity/main.tf
@@ -1,11 +1,11 @@
 # Set up the IAM workload identity pool and provider for Skyporten integration
-resource "google_iam_workload_identity_pool" "maskinporten_test" {
+resource "google_iam_workload_identity_pool" "maskinporten" {
   workload_identity_pool_id = var.workload_pool_id
   display_name              = var.workload_pool_id
 }
 
 resource "google_iam_workload_identity_pool_provider" "maskinporten" {
-  workload_identity_pool_id          = google_iam_workload_identity_pool.maskinporten_test.workload_identity_pool_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.maskinporten.workload_identity_pool_id
   workload_identity_pool_provider_id = var.provider_id
   attribute_mapping = {
     "attribute.maskinportenscope" = "assertion.scope"
@@ -31,8 +31,9 @@ module "skyporten_consumer" {
   org_number             = each.value
   project_number         = var.project_number
 
-  workload_identity_pool_id = google_iam_workload_identity_pool.maskinporten_test.workload_identity_pool_id
+  workload_identity_pool_id = google_iam_workload_identity_pool.maskinporten.workload_identity_pool_id
   providers = {
     google = google
   }
+  depends_on = [ google_iam_workload_identity_pool.maskinporten, google_iam_workload_identity_pool_provider.maskinporten ]
 }

--- a/terraform/modules/skyporten_workload_identity/main.tf
+++ b/terraform/modules/skyporten_workload_identity/main.tf
@@ -25,15 +25,17 @@ module "skyporten_consumer" {
   source   = "./skyporten_consumers"
   for_each = var.consumer_org_numbers
 
-  maskinporten_scope     = var.maskinporten_scope
-  maskinporten_client_id = "0192:${each.value}"
-  region                 = var.region
-  org_number             = each.value
-  project_number         = var.project_number
-
+  maskinporten_scope        = var.maskinporten_scope
+  maskinporten_client_id    = "0192:${each.value}"
+  region                    = var.region
+  org_number                = each.value
+  project_number            = var.project_number
   workload_identity_pool_id = google_iam_workload_identity_pool.maskinporten.workload_identity_pool_id
+  project_id                = var.project_id
+
   providers = {
     google = google
   }
-  depends_on = [ google_iam_workload_identity_pool.maskinporten, google_iam_workload_identity_pool_provider.maskinporten ]
+
+  depends_on = [google_iam_workload_identity_pool.maskinporten, google_iam_workload_identity_pool_provider.maskinporten]
 }

--- a/terraform/modules/skyporten_workload_identity/main.tf
+++ b/terraform/modules/skyporten_workload_identity/main.tf
@@ -23,7 +23,7 @@ resource "google_iam_workload_identity_pool_provider" "maskinporten" {
 # Define consumers and access levels
 module "skyporten_consumer" {
   source   = "./skyporten_consumers"
-  for_each = var.org_numbers
+  for_each = var.consumer_org_numbers
 
   maskinporten_scope     = var.maskinporten_scope
   maskinporten_client_id = "0192:${each.value}"

--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/backend.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}

--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
@@ -1,0 +1,37 @@
+resource "google_service_account" "skyporten_consumer" {
+  account_id   = "skyporten-consumer-${var.org_number}"
+  display_name = "Skyporten consumer (org. ${var.org_number}) for scope ${var.maskinporten_scope}"
+}
+
+data "google_iam_policy" "clientaccess" {
+  binding {
+    role = "roles/iam.workloadIdentityUser"
+
+    members = [
+      "principalSet://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/attribute.clientaccess/client::${var.maskinporten_client_id}::${var.maskinporten_scope}",
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "foo" {
+  service_account_id = google_service_account.skyporten_consumer.name
+  policy_data        = data.google_iam_policy.clientaccess.policy_data
+}
+
+resource "google_storage_bucket" "skyporten_bucket" {
+  name     = "skyporten-test-${var.org_number}"
+  location = var.region
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_iam_member" "legacy_bucket_reader" {
+  bucket   = google_storage_bucket.skyporten_bucket.name
+  role     = "roles/storage.legacyBucketReader"
+  member   = "serviceAccount:${google_service_account.skyporten_consumer.email}"
+}
+
+resource "google_storage_bucket_iam_member" "object_admin" {
+  bucket   = google_storage_bucket.skyporten_bucket.name
+  role     = "roles/storage.objectAdmin"
+  member   = "serviceAccount:${google_service_account.skyporten_consumer.email}"
+}

--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
@@ -7,7 +7,7 @@ resource "google_service_account" "skyporten_consumer" {
   description = "Service account for the Skyporten consumer for organization ${var.org_number} with scope ${local.maskinporten_scope}"
 }
 
-data "google_iam_policy" "clientaccess" {
+data "google_iam_policy" "client_access" {
   binding {
     role = "roles/iam.workloadIdentityUser"
 
@@ -17,9 +17,9 @@ data "google_iam_policy" "clientaccess" {
   }
 }
 
-resource "google_service_account_iam_policy" "foo" {
+resource "google_service_account_iam_policy" "workload_identity_policy" {
   service_account_id = google_service_account.skyporten_consumer.name
-  policy_data        = data.google_iam_policy.clientaccess.policy_data
+  policy_data        = data.google_iam_policy.client_access.policy_data
 }
 
 resource "google_storage_bucket" "skyporten_bucket" {

--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
@@ -28,14 +28,15 @@ resource "google_storage_bucket" "skyporten_bucket" {
   uniform_bucket_level_access = true
 }
 
-resource "google_storage_bucket_iam_member" "legacy_bucket_reader" {
+resource "google_storage_bucket_iam_member" "storage_viewer" {
   bucket = google_storage_bucket.skyporten_bucket.name
-  role   = "roles/storage.legacyBucketReader"
+  role   = "roles/storage.viewer"
   member = "serviceAccount:${google_service_account.skyporten_consumer.email}"
 }
 
-resource "google_storage_bucket_iam_member" "object_admin" {
+resource "google_storage_bucket_iam_member" "object_viewer" {
   bucket = google_storage_bucket.skyporten_bucket.name
-  role   = "roles/storage.objectAdmin"
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.skyporten_consumer.email}"
 }
+

--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
@@ -1,6 +1,10 @@
+locals {
+  maskinporten_scope = "${var.main_scope}:${var.sub_scope}"
+}
+
 resource "google_service_account" "skyporten_consumer" {
-  account_id   = "skyporten-consumer-${var.org_number}"
-  display_name = "Skyporten consumer (org. ${var.org_number}) for scope ${var.maskinporten_scope}"
+  account_id  = "skyporten-consumer-${var.sub_scope}-${var.org_number}"
+  description = "Service account for the Skyporten consumer for organization ${var.org_number} with scope ${local.maskinporten_scope}"
 }
 
 data "google_iam_policy" "clientaccess" {
@@ -8,7 +12,7 @@ data "google_iam_policy" "clientaccess" {
     role = "roles/iam.workloadIdentityUser"
 
     members = [
-      "principalSet://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/attribute.clientaccess/client::${var.maskinporten_client_id}::${var.maskinporten_scope}",
+      "principalSet://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/attribute.clientaccess/client::${var.maskinporten_client_id}::${local.maskinporten_scope}",
     ]
   }
 }
@@ -19,7 +23,7 @@ resource "google_service_account_iam_policy" "foo" {
 }
 
 resource "google_storage_bucket" "skyporten_bucket" {
-  name                        = "skyporten-${var.org_number}-${var.project_id}"
+  name                        = "skyporten-${var.sub_scope}-${var.org_number}-${var.project_id}"
   location                    = var.region
   uniform_bucket_level_access = true
 }

--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
@@ -23,7 +23,7 @@ resource "google_service_account_iam_policy" "foo" {
 }
 
 resource "google_storage_bucket" "skyporten_bucket" {
-  name                        = "skyporten-${var.sub_scope}-${var.org_number}-${var.project_id}"
+  name                        = "sp-${var.sub_scope}-${var.org_number}-${var.project_id}"
   location                    = var.region
   uniform_bucket_level_access = true
 }

--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
@@ -19,19 +19,19 @@ resource "google_service_account_iam_policy" "foo" {
 }
 
 resource "google_storage_bucket" "skyporten_bucket" {
-  name     = "skyporten-${var.org_number}"
-  location = var.region
+  name                        = "skyporten-${var.org_number}-${var.project_id}"
+  location                    = var.region
   uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_member" "legacy_bucket_reader" {
-  bucket   = google_storage_bucket.skyporten_bucket.name
-  role     = "roles/storage.legacyBucketReader"
-  member   = "serviceAccount:${google_service_account.skyporten_consumer.email}"
+  bucket = google_storage_bucket.skyporten_bucket.name
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.skyporten_consumer.email}"
 }
 
 resource "google_storage_bucket_iam_member" "object_admin" {
-  bucket   = google_storage_bucket.skyporten_bucket.name
-  role     = "roles/storage.objectAdmin"
-  member   = "serviceAccount:${google_service_account.skyporten_consumer.email}"
+  bucket = google_storage_bucket.skyporten_bucket.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.skyporten_consumer.email}"
 }

--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
@@ -19,7 +19,7 @@ resource "google_service_account_iam_policy" "foo" {
 }
 
 resource "google_storage_bucket" "skyporten_bucket" {
-  name     = "skyporten-test-${var.org_number}"
+  name     = "skyporten-${var.org_number}"
   location = var.region
   uniform_bucket_level_access = true
 }

--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "google_service_account" "skyporten_consumer" {
-  account_id  = "skyporten-consumer-${var.sub_scope}-${var.org_number}"
+  account_id  = "sp-${var.sub_scope}-${var.org_number}"
   description = "Service account for the Skyporten consumer for organization ${var.org_number} with scope ${local.maskinporten_scope}"
 }
 

--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/variables.tf
@@ -1,7 +1,3 @@
-variable "maskinporten_scope" {
-  description = "The scope for the Maskinporten client. Format <ORGANIZATION_SCOPE:SUB_SCOPE>"
-}
-
 variable "org_number" {
   description = "The organization number that should be allowed to access the Skyporten integration"
 }
@@ -24,4 +20,17 @@ variable "project_number" {
 
 variable "project_id" {
   description = "The project ID of the project"
+}
+
+variable "consumer_name" {
+  description = "The name of the consumer (organization)"
+}
+
+variable "main_scope" {
+  description = "The main organisation scope for the Maskinporten client."
+  default     = "kartverk"
+}
+
+variable "sub_scope" {
+  description = "The sub scope for the Maskinporten client."
 }

--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/variables.tf
@@ -21,3 +21,7 @@ variable "maskinporten_client_id" {
 variable "project_number" {
   description = "The project number of the project"
 }
+
+variable "project_id" {
+  description = "The project ID of the project"
+}

--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/variables.tf
@@ -1,0 +1,23 @@
+variable "maskinporten_scope" {
+  description = "The scope for the Maskinporten client. Format <ORGANIZATION_SCOPE:SUB_SCOPE>"
+}
+
+variable "org_number" {
+  description = "The organization number that should be allowed to access the Skyporten integration"
+}
+
+variable "region" {
+  description = "The region to deploy the resources in"
+}
+
+variable "workload_identity_pool_id" {
+  description = "The ID of the workload pool to be used for the Skyporten integration"
+}
+
+variable "maskinporten_client_id" {
+  description = "The Maskinporten client ID for the consumer"
+}
+
+variable "project_number" {
+  description = "The project number of the project"
+}

--- a/terraform/modules/skyporten_workload_identity/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/variables.tf
@@ -10,7 +10,7 @@ variable "required_audience" {
   description = "The required audience for the OICD identity pool provider. Does not need to be a valid domain"
 }
 
-variable "org_numbers" {
+variable "consumer_org_numbers" {
   description = "The organization numbers that should be allowed to access the Skyporten integration"
 }
 

--- a/terraform/modules/skyporten_workload_identity/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/variables.tf
@@ -25,3 +25,7 @@ variable "region" {
 variable "project_number" {
   description = "The project number of the project"
 }
+
+variable "project_id" {
+  description = "The project ID of the project"
+}

--- a/terraform/modules/skyporten_workload_identity/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/variables.tf
@@ -1,0 +1,27 @@
+variable "workload_pool_id" {
+  description = "The ID of the workload pool to be used for the Skyporten integration"
+}
+
+variable "provider_id" {
+  description = "The provider ID for the OICD identity pool provider"
+}
+
+variable "required_audience" {
+  description = "The required audience for the OICD identity pool provider. Does not need to be a valid domain"
+}
+
+variable "org_numbers" {
+  description = "The organization numbers that should be allowed to access the Skyporten integration"
+}
+
+variable "maskinporten_scope" {
+  description = "The scope for the Maskinporten client. Format <ORGANIZATION_SCOPE:SUB_SCOPE>"
+}
+
+variable "region" {
+  description = "The region to deploy the resources in"
+}
+
+variable "project_number" {
+  description = "The project number of the project"
+}

--- a/terraform/modules/skyporten_workload_identity/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/variables.tf
@@ -7,7 +7,7 @@ variable "provider_id" {
 }
 
 variable "required_audience" {
-  description = "The required audience for the OICD identity pool provider. Does not need to be a valid domain"
+  description = "The required audience for the OICD identity pool provider. Docs: https://docs.digdir.no/docs/idporten/oidc/oidc_func_aud.html"
 }
 
 variable "consumer_org_numbers" {
@@ -28,4 +28,22 @@ variable "project_number" {
 
 variable "project_id" {
   description = "The project ID of the project"
+}
+
+variable "display_name" {
+  description = "The display name of the workload identity pool"
+}
+
+variable "issuer_uri" {
+  description = "The issuer URI for the OICD identity pool provider"
+  default     = "https://test.sky.maskinporten.no"
+}
+
+variable "main_scope" {
+  description = "The main organisation scope for the Maskinporten client."
+  default     = "kartverk"
+}
+
+variable "sub_scope" {
+  description = "The sub scope for the Maskinporten client."
 }

--- a/terraform/modules/skyporten_workload_identity/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/variables.tf
@@ -14,10 +14,6 @@ variable "consumer_org_numbers" {
   description = "The organization numbers that should be allowed to access the Skyporten integration"
 }
 
-variable "maskinporten_scope" {
-  description = "The scope for the Maskinporten client. Format <ORGANIZATION_SCOPE:SUB_SCOPE>"
-}
-
 variable "region" {
   description = "The region to deploy the resources in"
 }

--- a/terraform/modules/skyporten_workload_identity/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/variables.tf
@@ -26,7 +26,7 @@ variable "project_id" {
   description = "The project ID of the project"
 }
 
-variable "display_name" {
+variable "workload_identity_pool_display_name" {
   description = "The display name of the workload identity pool"
 }
 

--- a/terraform/modules/skyporten_workload_identity/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/variables.tf
@@ -2,6 +2,10 @@ variable "workload_pool_id" {
   description = "The ID of the workload pool to be used for the Skyporten integration"
 }
 
+variable "workload_identity_pool_display_name" {
+  description = "The display name of the workload identity pool"
+}
+
 variable "provider_id" {
   description = "The provider ID for the OICD identity pool provider"
 }
@@ -26,9 +30,6 @@ variable "project_id" {
   description = "The project ID of the project"
 }
 
-variable "workload_identity_pool_display_name" {
-  description = "The display name of the workload identity pool"
-}
 
 variable "issuer_uri" {
   description = "The issuer URI for the OICD identity pool provider"


### PR DESCRIPTION
En modul som legger til rette for å sette opp deling av data gjennom [Skyporten](https://docs.digdir.no/docs/Maskinporten/maskinporten_skyporten_gcp#knytt-service-account-sammen-med-ressursen-som-skal-deles). 

Modulen tar høyde for at man kan ha en eller flere konsumenter (definert med org.nummer) av et scope som er konfigurert opp på https://samarbeid.digdir.no/. Lager en dedikert service account og bøtte med nødvendige tilganger for en organisasjon som kan konsumere det som ligger i bøtta. 

Hittil har vi testet med delta-sharing-filer som kan leses inn fra både Jupyter Notebooks og Databricks Notebooks. Hvordan man konsumerer i notebooks finner man [her](https://github.com/entur/sd-skyporten-examples/tree/main/gcp/deltasharing/consumer/examples). 

Eksempel-bruk:
```terraform
module "skyporten_integration_setup" {
  source = "git::https://github.com/kartverket/dask-modules//terraform/modules/skyporten_workload_identity?ref=main"

  workload_pool_id                    = "skyporten-${var.env}"
  provider_id                         = "skyporten-provider-${var.env}"
  required_audience                   = "https://skyporten.kartverk"
  main_scope                          = "kartverk"
  sub_scope                           = "adminenheter"
  consumer_org_numbers                = toset(["310659827"])
  project_number                      = var.project_number
  region                              = var.region
  project_id                          = var.project_id
  workload_identity_pool_display_name = "Test admin enheter"

  providers = {
    google = google
  }
}
```