### PR TITLE
Bruk params og send den rundt via alle flytene

### DIFF
--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -15,6 +15,9 @@ on:
         description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
         required: true
         type: string
+      script_params:
+        description: "Parameters to use in the script"
+        required: false
       debug_mode:
         description: "If the workflow should actually create resources or just run through without doing so."
         required: false
@@ -81,6 +84,7 @@ jobs:
       auth_project_number: ${{ inputs.auth_project_number }}
       service_account: ${{ inputs.service_account }}
       team_name: ${{ inputs.team_name }}
+      params: ${{ inputs.script_params }}
       step_id: setup-ingestor
 
 

--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -140,4 +140,5 @@ jobs:
       service_account: ${{ inputs.service_account }}
       team_name: ${{ inputs.team_name }}
       step_id: ${{ inputs.step_id }}
+      params: ${{ inputs.script_params }}
     

--- a/.github/workflows/publish-message-pubsub.yml
+++ b/.github/workflows/publish-message-pubsub.yml
@@ -19,12 +19,18 @@ on:
         description: "The step id to notify completion for to the pub sub onboarding topic."
         required: true
         type: string
+      params:
+        description: "The params appended to by each step of the onboarding flow."
+        required: false
+        type: string
+        default: "null"
 
 env:
   AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
   SERVICE_ACCOUNT: ${{ inputs.service_account }}
   TEAM_NAME: ${{ inputs.team_name }}
   STEP_ID: ${{ inputs.step_id }}
+  PARAMS: ${{ inputs.params }}
   PUBSUB_TOPIC: onboarding_topic
 
 
@@ -55,5 +61,5 @@ jobs:
 
       - name: Add message to PubSub topic
         run: |
-          gcloud pubsub topics publish ${{ env.PUBSUB_TOPIC }} --message='{ "team_name": "${{ env.TEAM_NAME }}", step: "${{ env.STEP_ID }}" }'
+          gcloud pubsub topics publish ${{ env.PUBSUB_TOPIC }} --message='{ "team_name": "${{ env.TEAM_NAME }}", step: "${{ env.STEP_ID }}", "params": ${{ env.PARAMS }} }'
 


### PR DESCRIPTION
For at onboardingsflyten skal få all infoen den trenger i alle stegene, gjør jeg nå slik at script-params flyter gjennom hele onboardingsflyten. Den begynner med lite info i start-steget, også blir den populert med gcp-info i løpet av de ulike stegene.