### PR TITLE
Modul for tilgangsstyring av tabeller i et skjema

### DIFF
--- a/terraform/modules/dbx_tables_access/backend.tf
+++ b/terraform/modules/dbx_tables_access/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    databricks = {
+      source = "databricks/databricks"
+    }
+  }
+}

--- a/terraform/modules/dbx_tables_access/dbx_grant_table_access/backend.tf
+++ b/terraform/modules/dbx_tables_access/dbx_grant_table_access/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    databricks = {
+      source = "databricks/databricks"
+    }
+  }
+}

--- a/terraform/modules/dbx_tables_access/dbx_grant_table_access/main.tf
+++ b/terraform/modules/dbx_tables_access/dbx_grant_table_access/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_grant" "table_grants" {
+  for_each = var.ad_group_names
+
+  principal  = each.value
+  privileges = var.table_privileges
+  table      = var.full_table_name
+}

--- a/terraform/modules/dbx_tables_access/dbx_grant_table_access/variables.tf
+++ b/terraform/modules/dbx_tables_access/dbx_grant_table_access/variables.tf
@@ -1,0 +1,14 @@
+variable "ad_group_names" {
+  description = "Set of AD group names to grant access to the catalog"
+  type        = set(string)
+}
+
+variable "full_table_name" {
+  description = "Name of the table to grant access to"
+  type        = string
+}
+
+variable "table_privileges" {
+  description = "List of privileges to grant on the table. Can be APPLY_TAG, MODIFY, SELECT, ALL_PRIVILEGES, or a combination of these"
+  type        = list(string)
+}

--- a/terraform/modules/dbx_tables_access/main.tf
+++ b/terraform/modules/dbx_tables_access/main.tf
@@ -1,0 +1,26 @@
+# Module for granting access to one (or more) tables for one (or more) product teams in Databricks
+# The tables have to be in the same schema and catalog
+
+resource "databricks_grant" "catalog_grants" {
+  for_each = var.ad_group_names
+
+  principal  = each.value
+  privileges = ["USE_CATALOG"]
+  catalog    = var.catalog_name
+}
+
+resource "databricks_grant" "schema_grants" {
+  for_each = var.ad_group_names
+
+  principal  = each.value
+  privileges = ["USE_SCHEMA"]
+  schema     = "${var.catalog_name}.${var.schema_name}"
+}
+
+module "grant_access_to_tables" {
+  source           = "./dbx_grant_table_access"
+  for_each         = var.tables_privileges_map
+  ad_group_names   = var.ad_group_names
+  full_table_name  = "${var.catalog_name}.${var.schema_name}.${each.key}"
+  table_privileges = each.value
+}

--- a/terraform/modules/dbx_tables_access/variables.tf
+++ b/terraform/modules/dbx_tables_access/variables.tf
@@ -1,0 +1,19 @@
+variable "ad_group_names" {
+  description = "Set of AD group names to grant access to the catalog"
+  type        = set(string)
+}
+
+variable "catalog_name" {
+  description = "Name of the catalog to grant access to"
+  type        = string
+}
+
+variable "schema_name" {
+  description = "Name of the schema to grant access to"
+  type        = string
+}
+
+variable "tables_privileges_map" {
+  description = "Map of table names to privileges to grant on the table. Can be APPLY_TAG, MODIFY, SELECT, ALL_PRIVILEGES, or a combination of these"
+  type        = map(list(string))
+}


### PR DESCRIPTION
Produktteam har et behov for å provisjonere opp tilganger til tabeller i katalogen deres. Lager derfor en modul som produktteamene kan bruke, der man kan gi tilgang til ett (eller flere) teams i en (eller flere) tabeller med forskjellige typer tilganger. 

Merk at modulen bare kan brukes på flere tabeller i samme skjema og katalog.  

Eksempel på bruk:
```terraform
module "create_grants_to_table_for_silver_schema" {
  source  = "git::https://github.com/kartverket/dask-modules//terraform/modules/dbx_tables_access"
  ad_group_names = toset(["CLOUD_SK_TEAM_Innsikt", "CLOUD_SK_TEAM_Egenregistrering"])
  catalog_name   = var.catalog_name # Forutsatt at dere har spesifisert katalog-navn i tfvars
  schema_name    = "silver"
  tables_privileges_map = {
    kommuner  = ["SELECT", "APPLY_TAG", "MODIFY"],
    postnummer = ["SELECT"]
  }
  providers = {
    databricks = databricks 
  }
}
```