### PR TITLE
Gjør PR-er til draft når de opprettes

### DIFF
--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -132,7 +132,8 @@ jobs:
                 body: JSON.stringify({
                     title: 'Add new team from DASK CI workflow',
                     head: 'dask-onboarding-ci-${{ env.TEAM_NAME }}',
-                    base: 'main'
+                    base: 'main',
+                    draft: true
                 })
             };
 


### PR DESCRIPTION
Defaulter til draft-PR når vi lager PR-er i repoer. Både for å ikke spamme SKIP, men også fordi det er ryddig å se over før man åpner den for review