### PR TITLE
Bruk prosjektnavn istedenfor teamnavn

### DIFF
--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -75,6 +75,7 @@ jobs:
           echo "git status: $(git status)"
           echo "git push"
           git push -u origin main
+          
   send_success_message_to_pubsub:
     needs: create_and_clone_repo
     uses: ./.github/workflows/publish-message-pubsub.yml

--- a/scripts/dask_infrastructure.py
+++ b/scripts/dask_infrastructure.py
@@ -2,31 +2,32 @@ import sys
 import os
 import json
 
-def edit_file(filepath, json_obj):
-    team_name: str = json_obj.get("team_name")
+def edit_file(filepath, params):
+    team_name: str = params.get("team_name")
+    project_name: str = params.get("project_name")
 
-    ad_group_name: str = json_obj["ad_groups"][0]
-    area_name: str = json_obj["area_name"]
-    project_id_map: dict = json_obj["gcp_project_ids"]
+    ad_group_name: str = params["ad_groups"][0]
+    area_name: str = params["area_name"]
+    project_id_map: dict = params["gcp_project_ids"]
 
     # Define the new team data
-    new_team_data = generate_module_definition(ad_group_name, team_name, area_name, project_id_map)
+    new_team_data = generate_module_definition(ad_group_name, team_name, area_name, project_name, project_id_map)
 
     append_content_to_end_of_file(filepath, new_team_data)
 
-def generate_module_definition(ad_group_name: str, team_name: str, area_name: str, project_id_map: dict) -> str: 
+def generate_module_definition(ad_group_name: str, team_name: str, area_name: str, project_name: str, project_id_map: dict) -> str: 
     module = f'''
-    module "{team_name.lower()}" {{
+    module "{project_name.lower()}" {{
       source = "../dbx_team_resources"
 
       ad_group_name = "CLOUD_SK_TEAM_{ad_group_name}"
       team_name     = "{team_name.lower()}"
       area_name     = "{area_name.lower()}"
       deploy_sa_map = {{
-        sandbox = "{team_name.lower()}-deploy@{project_id_map['sandbox']}.iam.gserviceaccount.com",
-        dev     = "{team_name.lower()}-deploy@{project_id_map['dev']}.iam.gserviceaccount.com",
-        test    = "{team_name.lower()}-deploy@{project_id_map['test']}.iam.gserviceaccount.com",
-        prod    = "{team_name.lower()}-deploy@{project_id_map['prod']}.iam.gserviceaccount.com"
+        sandbox = "{project_name.lower()}-deploy@{project_id_map['sandbox']}.iam.gserviceaccount.com",
+        dev     = "{project_name.lower()}-deploy@{project_id_map['dev']}.iam.gserviceaccount.com",
+        test    = "{project_name.lower()}-deploy@{project_id_map['test']}.iam.gserviceaccount.com",
+        prod    = "{project_name.lower()}-deploy@{project_id_map['prod']}.iam.gserviceaccount.com"
       }}
       projects = {{
         sandbox = "{project_id_map['sandbox']}",
@@ -74,6 +75,6 @@ if __name__ == "__main__":
 
     file_path = sys.argv[1]
     json_str = sys.argv[2]
-    json_obj = json.loads(json_str)
+    params = json.loads(json_str)
 
-    edit_file(file_path, json_obj)
+    edit_file(file_path, params)

--- a/scripts/dask_infrastructure.py
+++ b/scripts/dask_infrastructure.py
@@ -21,13 +21,13 @@ def generate_module_definition(ad_group_name: str, team_name: str, area_name: st
       source = "../dbx_team_resources"
 
       ad_group_name = "CLOUD_SK_TEAM_{ad_group_name}"
-      team_name     = "{team_name.lower()}"
+      team_name     = "{project_name.lower()}"
       area_name     = "{area_name.lower()}"
       deploy_sa_map = {{
-        sandbox = "{project_name.lower()}-deploy@{project_id_map['sandbox']}.iam.gserviceaccount.com",
-        dev     = "{project_name.lower()}-deploy@{project_id_map['dev']}.iam.gserviceaccount.com",
-        test    = "{project_name.lower()}-deploy@{project_id_map['test']}.iam.gserviceaccount.com",
-        prod    = "{project_name.lower()}-deploy@{project_id_map['prod']}.iam.gserviceaccount.com"
+        sandbox = "{team_name.lower()}-deploy@{project_id_map['sandbox']}.iam.gserviceaccount.com",
+        dev     = "{team_name.lower()}-deploy@{project_id_map['dev']}.iam.gserviceaccount.com",
+        test    = "{team_name.lower()}-deploy@{project_id_map['test']}.iam.gserviceaccount.com",
+        prod    = "{team_name.lower()}-deploy@{project_id_map['prod']}.iam.gserviceaccount.com"
       }}
       projects = {{
         sandbox = "{project_id_map['sandbox']}",

--- a/scripts/gcp_service_accounts.py
+++ b/scripts/gcp_service_accounts.py
@@ -22,7 +22,7 @@ def generate_module_definition(team_name: str, project_name: str) -> str:
             "roles/cloudscheduler.admin"
         ]
         env                   = var.env
-        project_id            = var.{team_name.lower()}_project_id
+        project_id            = var.{project_name}_project_id
         kubernetes_project_id = var.kubernetes_project_id
         can_manage_sa         = true
     }}
@@ -41,10 +41,10 @@ def append_content_to_end_of_file(file_path: str, content: str) -> None:
             file.writelines(lines)
             file.close()
 
-def edit_file(file_path, json_obj):
-    team_name: str = json_obj.get("team_name")
-    project_name: str = json_obj.get("project_name")
-    project_ids = json_obj["gcp_project_ids"]
+def edit_file(file_path, params):
+    team_name: str = params.get("team_name")
+    project_name: str = params.get("project_name")
+    project_ids = params["gcp_project_ids"]
     project_id_sandbox = project_ids["sandbox"]
     project_id_dev = project_ids["dev"]
     project_id_test = project_ids["test"]
@@ -55,11 +55,11 @@ def edit_file(file_path, json_obj):
     append_content_to_end_of_file(file_path + "/modules.tf", module_definition)
 
     # Handle variables.tf
-    variable_def = f'variable "{team_name.lower()}_project_id" {{}}\n'
+    variable_def = f'variable "{project_name}_project_id" {{}}\n'
     append_content_to_end_of_file(file_path + "/variables.tf", variable_def)
 
     # Handle *.tfvars files
-    get_project_var_entry = lambda project: f'\n{team_name.lower()}_project_id = "{project}"'
+    get_project_var_entry = lambda project: f'\n{project_name}_project_id = "{project}"'
     
     sandbox_var_entry = get_project_var_entry(project_id_sandbox)
     append_content_to_end_of_file(file_path + "/sandbox.tfvars", sandbox_var_entry)

--- a/scripts/gcp_service_accounts.py
+++ b/scripts/gcp_service_accounts.py
@@ -3,9 +3,9 @@ import sys
 from typing import List
 
 
-def generate_module_definition(team_name: str) -> str: 
+def generate_module_definition(team_name: str, project_name: str) -> str: 
     module = f'''
-    module "{team_name.lower()}" {{
+    module "{project_name.lower()}" {{
         source    = "./project_team"
         team_name = "{team_name}"
         repositories = [
@@ -43,6 +43,7 @@ def append_content_to_end_of_file(file_path: str, content: str) -> None:
 
 def edit_file(file_path, json_obj):
     team_name: str = json_obj.get("team_name")
+    project_name: str = json_obj.get("project_name")
     project_ids = json_obj["gcp_project_ids"]
     project_id_sandbox = project_ids["sandbox"]
     project_id_dev = project_ids["dev"]
@@ -50,7 +51,7 @@ def edit_file(file_path, json_obj):
     project_id_prod = project_ids["prod"]
 
     # Handle modules.tf
-    module_definition = generate_module_definition(team_name)
+    module_definition = generate_module_definition(team_name, project_name)
     append_content_to_end_of_file(file_path + "/modules.tf", module_definition)
 
     # Handle variables.tf
@@ -80,8 +81,8 @@ if __name__ == "__main__":
 
     file_path = sys.argv[1]
     json_str = sys.argv[2]
-    json_obj = json.loads(json_str)
+    params = json.loads(json_str)
 
-    edit_file(file_path, json_obj)
+    edit_file(file_path, params)
 
 # python gcp_service_accounts.py './path/to/gcp_service_accounts' '{ "team_name": "TestTeam", "project_id_sandbox": "project-sandbox", "project_id_dev": "project-dev", "project_id_test": "project-test", "project_id_prod": "project-prod"  }'

--- a/scripts/iam.py
+++ b/scripts/iam.py
@@ -9,19 +9,19 @@ def find_line_ref_local_teams(lines: List[str]) -> int:
             return idx
         
 
-def edit_file(file_path, json_obj):
+def edit_file(file_path, params):
     with open(file_path) as file:
-        team_name: str = json_obj.get("team_name")
-        ad_groups: List[str] = json_obj.get("ad_groups")
+        project_name: str = params.get("project_name")
+        ad_groups: List[str] = params.get("ad_groups")
 
-        print("Team Name:", team_name)
+        print("Project Name:", project_name)
         print("AD Groups:", ad_groups)
 
         lines = file.readlines()
         file.close()
 
         last_teams_ref_idx = find_line_ref_local_teams(lines)
-        lines.insert(last_teams_ref_idx + 3, f'"{team_name}"= {json.dumps(ad_groups)},\n')
+        lines.insert(last_teams_ref_idx + 3, f'"{project_name}"= {json.dumps(ad_groups)},\n')
 
         with open(file_path, 'w') as file:
             file.writelines(lines)
@@ -35,6 +35,6 @@ if __name__ == "__main__":
 
     file_path = sys.argv[1]
     json_str = sys.argv[2]
-    json_obj = json.loads(json_str)
+    params = json.loads(json_str)
 
-    edit_file(file_path, json_obj)
+    edit_file(file_path, params)


### PR DESCRIPTION
Ett team kan ha flere prosjekter tilknyttet seg. Bruker derfor heller prosjektnavnet når vi skal lage PR-er i IAM/gcp-service-accounts