### PR TITLE
Juster IAM- og infra-script til å ta høyde for nye AD-grupper

### DIFF
--- a/scripts/dask_infrastructure.py
+++ b/scripts/dask_infrastructure.py
@@ -20,7 +20,7 @@ def generate_module_definition(ad_group_name: str, team_name: str, area_name: st
     module "{project_name.lower()}" {{
       source = "../dbx_team_resources"
 
-      ad_group_name = "CLOUD_SK_TEAM_{ad_group_name}"
+      ad_group_name = "AAD - TF - TEAM - {ad_group_name}"
       team_name     = "{project_name.lower()}"
       area_name     = "{area_name.lower()}"
       deploy_sa_map = {{

--- a/scripts/iam.py
+++ b/scripts/iam.py
@@ -21,7 +21,8 @@ def edit_file(file_path, params):
         file.close()
 
         last_teams_ref_idx = find_line_ref_local_teams(lines)
-        lines.insert(last_teams_ref_idx + 3, f'"{project_name}"= "aad-tf-team-{json.dumps(ad_groups).lower()}@kartverket.no",\n')
+        ad_group_formatted = json.dumps(ad_groups).replace(' ', '').lower()
+        lines.insert(last_teams_ref_idx + 3, f'"{project_name}"= "aad-tf-team-{ad_group_formatted}@kartverket.no",\n')
 
         with open(file_path, 'w') as file:
             file.writelines(lines)

--- a/scripts/iam.py
+++ b/scripts/iam.py
@@ -5,7 +5,7 @@ from typing import List
 
 def find_line_ref_local_teams(lines: List[str]) -> int:
     for (row, idx) in zip(lines, range(len(lines))):
-        if row.startswith('  teams = {'):
+        if row.startswith('  teams_v2 = {'):
             return idx
         
 
@@ -21,7 +21,7 @@ def edit_file(file_path, params):
         file.close()
 
         last_teams_ref_idx = find_line_ref_local_teams(lines)
-        lines.insert(last_teams_ref_idx + 3, f'"{project_name}"= {json.dumps(ad_groups)},\n')
+        lines.insert(last_teams_ref_idx + 3, f'"{project_name}"= "aad-tf-team-skvis{json.dumps(ad_groups).lower()}@kartverket.no",\n')
 
         with open(file_path, 'w') as file:
             file.writelines(lines)

--- a/scripts/iam.py
+++ b/scripts/iam.py
@@ -21,7 +21,7 @@ def edit_file(file_path, params):
         file.close()
 
         last_teams_ref_idx = find_line_ref_local_teams(lines)
-        lines.insert(last_teams_ref_idx + 3, f'"{project_name}"= "aad-tf-team-skvis{json.dumps(ad_groups).lower()}@kartverket.no",\n')
+        lines.insert(last_teams_ref_idx + 3, f'"{project_name}"= "aad-tf-team-{json.dumps(ad_groups).lower()}@kartverket.no",\n')
 
         with open(file_path, 'w') as file:
             file.writelines(lines)


### PR DESCRIPTION
På `kartverket.dev` så er bare de nye AD-gruppene støttet. Justerer derfor insert i IAM-repoet og `dask-infrastructure` slik at de nye gruppenavnene blir reflektert