### PR TITLE
Bruk prosjektnavn i dask-infra og gcp-service-accounts

### DIFF
--- a/scripts/dask_infrastructure.py
+++ b/scripts/dask_infrastructure.py
@@ -24,10 +24,10 @@ def generate_module_definition(ad_group_name: str, team_name: str, area_name: st
       team_name     = "{project_name.lower()}"
       area_name     = "{area_name.lower()}"
       deploy_sa_map = {{
-        sandbox = "{team_name.lower()}-deploy@{project_id_map['sandbox']}.iam.gserviceaccount.com",
-        dev     = "{team_name.lower()}-deploy@{project_id_map['dev']}.iam.gserviceaccount.com",
-        test    = "{team_name.lower()}-deploy@{project_id_map['test']}.iam.gserviceaccount.com",
-        prod    = "{team_name.lower()}-deploy@{project_id_map['prod']}.iam.gserviceaccount.com"
+        sandbox = "{project_name.lower()}-deploy@{project_id_map['sandbox']}.iam.gserviceaccount.com",
+        dev     = "{project_name.lower()}-deploy@{project_id_map['dev']}.iam.gserviceaccount.com",
+        test    = "{project_name.lower()}-deploy@{project_id_map['test']}.iam.gserviceaccount.com",
+        prod    = "{project_name.lower()}-deploy@{project_id_map['prod']}.iam.gserviceaccount.com"
       }}
       projects = {{
         sandbox = "{project_id_map['sandbox']}",

--- a/scripts/gcp_service_accounts.py
+++ b/scripts/gcp_service_accounts.py
@@ -7,9 +7,9 @@ def generate_module_definition(team_name: str, project_name: str) -> str:
     module = f'''
     module "{project_name.lower()}" {{
         source    = "./project_team"
-        team_name = "{team_name}"
+        team_name = "{project_name}"
         repositories = [
-            "kartverket/{team_name.lower()}-data-ingestor",
+            "kartverket/{project_name.lower()}-data-ingestor",
         ]
         extra_team_sa_roles = [
             "roles/resourcemanager.projectIamAdmin",


### PR DESCRIPTION
Quick fix for å få prosjektnavnet til å drille gjennom hele flyten