### PR TITLE
Legg til Dataplattform-team som co-owner av GCP-prosjekt for nye daskere

### DIFF
--- a/scripts/iam.py
+++ b/scripts/iam.py
@@ -22,7 +22,7 @@ def edit_file(file_path, params):
 
         last_teams_ref_idx = find_line_ref_local_teams(lines)
         ad_group_formatted = json.dumps(ad_group).replace(' ', '').replace('"', '').lower()
-        lines.insert(last_teams_ref_idx + 3, f'"{project_name}"= ["aad-tf-team-{ad_group_formatted}@kartverket.no"]\n')
+        lines.insert(last_teams_ref_idx + 3, f'"{project_name}"= ["aad-tf-team-{ad_group_formatted}@kartverket.no", "aad-tf-team-dataplattform@kartverket.no"]\n')
 
         with open(file_path, 'w') as file:
             file.writelines(lines)


### PR DESCRIPTION
Det er så mye rot som kan gå galt i oppstarten på prosjektet at vi bør legge oss selv til som co-owners av GCP-prosjektet som skal brukes i DASK-sammenheng, da kompetansen på teamet som onboardes ofte ikke er tilstrekkelig til å fikse opp i ting som går galt