### PR TITLE
Fjern alt test-relatert i scripts til onboarding

### DIFF
--- a/scripts/dask_infrastructure.py
+++ b/scripts/dask_infrastructure.py
@@ -26,13 +26,11 @@ def generate_module_definition(ad_group_name: str, area_name: str, project_name:
       deploy_sa_map = {{
         sandbox = "{project_name.lower()}-deploy@{project_id_map['sandbox']}.iam.gserviceaccount.com",
         dev     = "{project_name.lower()}-deploy@{project_id_map['dev']}.iam.gserviceaccount.com",
-        test    = "{project_name.lower()}-deploy@{project_id_map['test']}.iam.gserviceaccount.com",
         prod    = "{project_name.lower()}-deploy@{project_id_map['prod']}.iam.gserviceaccount.com"
       }}
       projects = {{
         sandbox = "{project_id_map['sandbox']}",
         dev     = "{project_id_map['dev']}",
-        test    = "{project_id_map['test']}",
         prod    = "{project_id_map['prod']}",
       }}
         

--- a/scripts/gcp_service_accounts.py
+++ b/scripts/gcp_service_accounts.py
@@ -36,7 +36,7 @@ def edit_file(file_path, params):
     project_name: str = params.get("project_name")
     project_ids = params["gcp_project_ids"]
     project_id_sandbox = project_ids["sandbox"]
-    project_id_test = project_ids["test"]
+    project_id_dev = project_ids["dev"]
     project_id_prod = project_ids["prod"]
 
     # Handle modules.tf
@@ -53,8 +53,8 @@ def edit_file(file_path, params):
     sandbox_var_entry = get_project_var_entry(project_id_sandbox)
     append_content_to_end_of_file(file_path + "/sandbox.tfvars", sandbox_var_entry)
 
-    test_var_entry = get_project_var_entry(project_id_test)
-    append_content_to_end_of_file(file_path + "/test.tfvars", test_var_entry)
+    dev_var_entry = get_project_var_entry(project_id_dev)
+    append_content_to_end_of_file(file_path + "/dev.tfvars", dev_var_entry)
 
     prod_var_entry = get_project_var_entry(project_id_prod)
     append_content_to_end_of_file(file_path + "/prod.tfvars", prod_var_entry)

--- a/scripts/gcp_service_accounts.py
+++ b/scripts/gcp_service_accounts.py
@@ -36,7 +36,6 @@ def edit_file(file_path, params):
     project_name: str = params.get("project_name")
     project_ids = params["gcp_project_ids"]
     project_id_sandbox = project_ids["sandbox"]
-    project_id_dev = project_ids["dev"]
     project_id_test = project_ids["test"]
     project_id_prod = project_ids["prod"]
 
@@ -53,9 +52,6 @@ def edit_file(file_path, params):
     
     sandbox_var_entry = get_project_var_entry(project_id_sandbox)
     append_content_to_end_of_file(file_path + "/sandbox.tfvars", sandbox_var_entry)
-
-    dev_var_entry = get_project_var_entry(project_id_dev)
-    append_content_to_end_of_file(file_path + "/dev.tfvars", dev_var_entry)
 
     test_var_entry = get_project_var_entry(project_id_test)
     append_content_to_end_of_file(file_path + "/test.tfvars", test_var_entry)


### PR DESCRIPTION
Venter til `dask-infrastructure` også har fjernet test-workspacet, da vi har en del avhengigheter som krever GCP-prosjekt og SA-er i nåværende oppsett