### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 organization: IT
 product: Dataplattformtjenester
 repo_types: [Library,Ops]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,39 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "dask-modules"
+  tags:
+  - "public"
+  - "internal"
+spec:
+  type: "library"
+  lifecycle: "production"
+  owner: "dataplattform"
+  system: "dataplattformtjenester"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_dask-modules"
+  title: "Security Champion dask-modules"
+spec:
+  type: "security_champion"
+  parent: "it_security_champions"
+  members:
+  - "augustdahl"
+  children:
+  - "resource:dask-modules"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "dask-modules"
+  links:
+  - url: "https://github.com/kartverket/dask-modules"
+    title: "dask-modules på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_dask-modules"
+  dependencyOf:
+  - "component:dask-modules"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.