### PR TITLE
Endre steg for å sjekke om repo eksisterer i Databricks eller ikke

### DIFF
--- a/.github/workflows/deploy-databricks.yml
+++ b/.github/workflows/deploy-databricks.yml
@@ -31,6 +31,10 @@ on:
         description: "The path to the repo where the notebooks are located in Databricks."
         required: true
         type: string
+      databricks_repo_folder:
+        description: "The folder in the Databricks workspace where the notebooks are located."
+        required: true
+        type: string
       databricks_host:
         description: "The host of the Databricks workspace."
         required: true
@@ -46,6 +50,7 @@ env:
   SERVICE_ACCOUNT: ${{ inputs.service_account }}
   PROJECT_ID: ${{ inputs.project_id }}
   ENVIRONMENT: ${{ inputs.environment }}
+  DATABRICKS_REPO_FOLDER: ${{ inputs.databricks_repo_folder }}
   DATABRICKS_REPO_PATH: ${{ inputs.databricks_repo_path }}
   REPO_URL: ${{ inputs.repo_url }}
   DATABRICKS_HOST: ${{ inputs.databricks_host }}
@@ -65,7 +70,7 @@ jobs:
           PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
           echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
   deploy_databricks:
-    needs: [ setup-env ]
+    needs: [setup-env]
     name: Databricks deploy to ${{ inputs.environment }}
     runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.environment }}
@@ -114,7 +119,7 @@ jobs:
       - name: Check if Databricks repo exists
         run: |
           set +e 
-          REPO_EXISTS=$(databricks workspace list /Workspace/Repos/ --output json | \
+          REPO_EXISTS=$(databricks workspace list $DATABRICKS_REPO_FOLDER --output json | \
             jq -r --arg REPO_PATH "$DATABRICKS_REPO_PATH" \
             'if . != null then (map(select(.path == $REPO_PATH)) | if length > 0 then "true" else "false" end) else "false" end')
           echo "REPO_EXISTS=$REPO_EXISTS" >> $GITHUB_ENV

--- a/.github/workflows/deploy-databricks.yml
+++ b/.github/workflows/deploy-databricks.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Check if Databricks repo exists
         run: |
           set +e 
-          REPO_EXISTS=$(databricks repos list --output json | \
+          REPO_EXISTS=$(databricks workspace list /Workspace/Repos/ --output json | \
             jq -r --arg REPO_PATH "$DATABRICKS_REPO_PATH" \
             'if . != null then (map(select(.path == $REPO_PATH)) | if length > 0 then "true" else "false" end) else "false" end')
           echo "REPO_EXISTS=$REPO_EXISTS" >> $GITHUB_ENV


### PR DESCRIPTION
Databricks har gjort en endring i CLI-et sitt så repos fungerer ikke lenger. Endrer derfor fra `databricks repos list` til `databricks workspace list $DATABRICKS_REPO_FOLDER` der `DATABRICKS_REPO_FOLDER` er pathen til teamets folder, mens `DATABRICKS_REPO_PATH` er hele veien ned til selve repoet. 

Dette gjør at man kan legge inn flere repoer i samme mappe for teamet sitt