### PR TITLE
Legg til muligheten for å injecte env-variabler til docker image

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: "./versions"
         type: string
+      env_vars:
+        description: "Optional environment variables to be injected at build time"
+        required: false
+        default: ""
+        type: string
     outputs:
       image_url:
         value: ${{ jobs.build.outputs.image_url }}
@@ -73,6 +78,7 @@ jobs:
           context: ${{ env.CONTEXT_PATH }}
           push: ${{ !github.event.pull_request.draft }}
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:latest
+          build-args: ${{ inputs.env_vars }}
 
       - name: Checkout the repository
         if: steps.check_changes.outputs.skip_build == 'false'

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -97,7 +97,7 @@ jobs:
               echo "\"${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}\"" > $DIRECTORY/${{ inputs.version_file_name }} 
           }
 
-          if [[ "${{ env.BRANCH }}" == "inject-docker-vars" ]]; then
+          if [[ "${{ env.BRANCH }}" == "main" ]]; then
               setup_directory 
           fi
 

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -97,7 +97,7 @@ jobs:
               echo "\"${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}\"" > $DIRECTORY/${{ inputs.version_file_name }} 
           }
 
-          if [[ "${{ env.BRANCH }}" == "main" ]]; then
+          if [[ "${{ env.BRANCH }}" == "inject-docker-vars" ]]; then
               setup_directory 
           fi
 


### PR DESCRIPTION
Miljøvariabler i React må settes build-time, og siden vi ønsker å skille Entra-applikasjonene i markedsplassen trenger vi en mekanisme for å dytte inn disse i workflowen som trigger nytt image. 

