### PR TITLE
fix cloud function modul

### DIFF
--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -6,10 +6,10 @@ resource "archive_file" "this" {
 }
 
 resource "google_storage_bucket_object" "this" {
-  name   = "${var.name}.${data.archive_file.this.output_sha}.zip"
+  name   = "${var.name}.${archive_file.this.output_sha}.zip"
   bucket = var.bucket_id
-  source = abspath(data.archive_file.this.output_path)
-  detect_md5hash = base64encode(data.archive_file.this.output_md5)
+  source = abspath(archive_file.this.output_path)
+  detect_md5hash = base64encode(archive_file.this.output_md5)
 }
 
 resource "google_cloudfunctions2_function" "this" {

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -3,12 +3,14 @@ data "archive_file" "this" {
   output_path = "${path.module}/lambda-files.zip"
   source_dir  = var.function_folder_location
   excludes    = var.excludes
+  output_file_mode = "0666"
 }
 
 resource "google_storage_bucket_object" "this" {
   name   = "${var.name}.${data.archive_file.this.output_sha}.zip"
   bucket = var.bucket_id
   source = data.archive_file.this.output_path
+  detect_md5hash = base64encode(data.archive_file.this.output_md5)
 }
 
 resource "google_cloudfunctions2_function" "this" {

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -1,6 +1,6 @@
 data "archive_file" "this" {
   type        = "zip"
-  output_path = "${path.root}/lambda-files.zip"
+  output_path = "${abspath(path.root)}/lambda-files.zip"
   source_dir  = var.function_folder_location
   excludes    = var.excludes
   output_file_mode = "0666"
@@ -9,7 +9,7 @@ data "archive_file" "this" {
 resource "google_storage_bucket_object" "this" {
   name   = "${var.name}.${data.archive_file.this.output_sha}.zip"
   bucket = var.bucket_id
-  source = data.archive_file.this.output_path
+  source = abspath(data.archive_file.this.output_path)
   detect_md5hash = base64encode(data.archive_file.this.output_md5)
 }
 

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -1,6 +1,6 @@
 data "archive_file" "this" {
   type        = "zip"
-  output_path = "${path.module}/lambda-files.zip"
+  output_path = "${path.root}/lambda-files.zip"
   source_dir  = var.function_folder_location
   excludes    = var.excludes
   output_file_mode = "0666"

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -1,6 +1,6 @@
 resource "archive_file" "this" {
   type        = "zip"
-  output_path = "${abspath(path.root)}/lambda-files.zip"
+  output_path = "${abspath(path.root)}/terraform_created_zip/${var.name}/lambda-files.zip"
   source_dir  = var.function_folder_location
   excludes    = var.excludes
 }

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -3,7 +3,6 @@ data "archive_file" "this" {
   output_path = "${abspath(path.root)}/lambda-files.zip"
   source_dir  = var.function_folder_location
   excludes    = var.excludes
-  output_file_mode = "0666"
 }
 
 resource "google_storage_bucket_object" "this" {

--- a/terraform/modules/cloud_function/function.tf
+++ b/terraform/modules/cloud_function/function.tf
@@ -1,4 +1,4 @@
-data "archive_file" "this" {
+resource "archive_file" "this" {
   type        = "zip"
   output_path = "${abspath(path.root)}/lambda-files.zip"
   source_dir  = var.function_folder_location

--- a/terraform/modules/cloud_function/outputs.tf
+++ b/terraform/modules/cloud_function/outputs.tf
@@ -35,3 +35,11 @@ output "current_dir" {
 output "module_dir" {
   value = abspath(path.module)
 }
+
+output "function_folder_path" {
+  value = var.function_folder_location
+}
+
+output "function_folder_abs_path" {
+  value = abspath(var.function_folder_location)
+}

--- a/terraform/modules/cloud_function/outputs.tf
+++ b/terraform/modules/cloud_function/outputs.tf
@@ -25,7 +25,7 @@ output "uri" {
 
 # _____________________DEBUG____________________ #
 output "archive_output_path" {
-  value = abspath(data.archive_file.this.output_path)
+  value = abspath(archive_file.this.output_path)
 }
 
 output "current_dir" {

--- a/terraform/modules/cloud_function/outputs.tf
+++ b/terraform/modules/cloud_function/outputs.tf
@@ -22,24 +22,3 @@ output "uri" {
   description = "The uri to reach the function"
   value       = google_cloudfunctions2_function.this.service_config[0].uri
 }
-
-# _____________________DEBUG____________________ #
-output "archive_output_path" {
-  value = abspath(archive_file.this.output_path)
-}
-
-output "current_dir" {
-  value = abspath(path.root)
-}
-
-output "module_dir" {
-  value = abspath(path.module)
-}
-
-output "function_folder_path" {
-  value = var.function_folder_location
-}
-
-output "function_folder_abs_path" {
-  value = abspath(var.function_folder_location)
-}

--- a/terraform/modules/cloud_function/outputs.tf
+++ b/terraform/modules/cloud_function/outputs.tf
@@ -22,3 +22,16 @@ output "uri" {
   description = "The uri to reach the function"
   value       = google_cloudfunctions2_function.this.service_config[0].uri
 }
+
+# _____________________DEBUG____________________ #
+output "archive_output_path" {
+  value = data.archive_file.this.output_path
+}
+
+output "current_dir" {
+  value = abspath(path.root)
+}
+
+output "module_dir" {
+  value = abspath(path.module)
+}

--- a/terraform/modules/cloud_function/outputs.tf
+++ b/terraform/modules/cloud_function/outputs.tf
@@ -25,7 +25,7 @@ output "uri" {
 
 # _____________________DEBUG____________________ #
 output "archive_output_path" {
-  value = data.archive_file.this.output_path
+  value = abspath(data.archive_file.this.output_path)
 }
 
 output "current_dir" {


### PR DESCRIPTION
Har byttet fra data archive_files til resource archive_files for å fikse at cloud functions filer kun blir zippet i plan steget og ikke apply steget. Resource achive_files er tagget som deprecated men som diskutert i [denne issue tråden ](https://github.com/hashicorp/terraform-provider-archive/issues/218)skal den mest sannsynlig ikke fjernes med det første.

Hvordan vi skal løses dette på en permanent basis er litt usikkert.