### PR TITLE
Let etter riktig objekt vi skal legge inn AD-gruppa i for IAM

### DIFF
--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -36,7 +36,6 @@ env:
   AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
   SERVICE_ACCOUNT: ${{ inputs.service_account }}
 
-
 jobs:
   create_and_clone_repo:
     runs-on: ubuntu-latest
@@ -79,11 +78,11 @@ jobs:
           echo "git status: $(git status)"
           echo "git push"
           git push -u origin main
-          
+
   send_success_message_to_pubsub:
     needs: create_and_clone_repo
     uses: ./.github/workflows/publish-message-pubsub.yml
-    permissions: 
+    permissions:
       id-token: write
     with:
       auth_project_number: ${{ inputs.auth_project_number }}
@@ -91,6 +90,3 @@ jobs:
       team_name: ${{ inputs.team_name }}
       params: ${{ inputs.script_params }}
       step_id: setup-ingestor
-
-
-

--- a/scripts/iam.py
+++ b/scripts/iam.py
@@ -5,7 +5,7 @@ from common import replace_special_characters
 
 def find_line_ref_local_teams(lines: List[str]) -> int:
     for (row, idx) in zip(lines, range(len(lines))):
-        if row.startswith('  teams_v2 = {'):
+        if row.startswith('  products_v2 = {'):
             return idx
         
 


### PR DESCRIPTION
SKIP har byttet navn på objektet sitt i IAM fra `teams_v2` til `products_v2`, så PR-opprettelse feiler. Det er sånn som kan skje, men det viser kanskje også at det er litt skjørt det oppsettet vi har nå i lag med SKIP. Har tatt det opp til diskusjon på Slack