### PR TITLE
Legger til newline før variabel for å unngå fmt-crash

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -19,7 +19,7 @@ def append_content_to_end_of_file(file_path: str, content: str) -> None:
     with open(file_path) as file:
         lines = file.readlines()
         file.close()
-        lines.insert(len(lines), content)
+        lines.insert(len(lines), '\n' + content)
 
         with open(file_path, 'w') as file:
             file.writelines(lines)


### PR DESCRIPTION
Når vi injecter filen kan det være at det ikke er en newline der, og da feiler workflowen. Legger derfor den til, og så fikser `terraform fmt -recursive` resten