### PR TITLE
Ta høyde for newlines i gcp-service-accounts

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -19,7 +19,11 @@ def append_content_to_end_of_file(file_path: str, content: str) -> None:
     with open(file_path) as file:
         lines = file.readlines()
         file.close()
-        lines.insert(len(lines), content)
+        
+        if lines and not lines[-1].endswith('\n'):
+            lines[-1] += '\n'
+
+        lines.insert(len(lines), '\n' + content)
 
         with open(file_path, 'w') as file:
             file.writelines(lines)


### PR DESCRIPTION
Vi er nødt til å ta høyde for at det ikke eksisterer noen newline der vi legger inn variabler, samtidig som at vi ikke ønsker å lage unødvendig mange newlines. 