### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: IT
 product: Dataplattformtjenester
 repo_types: [Library,Ops]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 
 * @kartverket/dask
 
-/.sikkerhet/ @augustdahl
+/.security/ @augustdahl

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,29 +11,3 @@ spec:
   lifecycle: "production"
   owner: "dataplattform"
   system: "dataplattformtjenester"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_dask-modules"
-  title: "Security Champion dask-modules"
-spec:
-  type: "security_champion"
-  parent: "it_security_champions"
-  members:
-  - "augustdahl"
-  children:
-  - "resource:dask-modules"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "dask-modules"
-  links:
-  - url: "https://github.com/kartverket/dask-modules"
-    title: "dask-modules på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_dask-modules"
-  dependencyOf:
-  - "component:dask-modules"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml