### PR TITLE
Bruk korrekt service account for Cloud Build

### DIFF
--- a/terraform/modules/cloud_function_v2/main.tf
+++ b/terraform/modules/cloud_function_v2/main.tf
@@ -32,6 +32,7 @@ resource "google_cloudfunctions2_function" "function" {
         object = google_storage_bucket_object.function_source.name
       }
     }
+    service_account = var.service_account_email
   }
   service_config {
     environment_variables = var.environment_variables

--- a/terraform/modules/cloud_function_v2/main.tf
+++ b/terraform/modules/cloud_function_v2/main.tf
@@ -32,7 +32,7 @@ resource "google_cloudfunctions2_function" "function" {
         object = google_storage_bucket_object.function_source.name
       }
     }
-    service_account = var.service_account_email
+    service_account = "projects/${var.project_id}/serviceAccounts/${var.service_account_email}"
   }
   service_config {
     environment_variables = var.environment_variables


### PR DESCRIPTION
GCP defaulter til den automatisk genererte compute SA-en. Setter derfor den SA-en som kommer fra input eksplisitt