### PR TITLE
Delta share to open

### DIFF
--- a/terraform/modules/db2open/backend.tf
+++ b/terraform/modules/db2open/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    databricks = {
+      source                = "databricks/databricks"
+      configuration_aliases = [databricks.workspace]
+    }
+  }
+}

--- a/terraform/modules/db2open/main.tf
+++ b/terraform/modules/db2open/main.tf
@@ -1,5 +1,9 @@
+locals {
+  valid_recipients = compact(var.recipients) # Removes empty strings
+}
+
 resource "random_password" "db2opensharecode" {
-  for_each = var.consumer_org_numbers
+  for_each = toset(local.valid_recipients)
 
   length  = 16
   special = true
@@ -8,28 +12,34 @@ resource "random_password" "db2opensharecode" {
 resource "databricks_recipient" "db2open" {
   provider = databricks.workspace
 
-  for_each = var.consumer_org_numbers
+  for_each = toset(local.valid_recipients)
 
-  name                = "recipient_${each.key}"
-  comment             = "Recipient av sb2open opprettet i Terraform for ${each.key}"
+  name                = "recipient_${var.share_name}_${each.key}"
+  comment             = "Recipient av db2open opprettet i Terraform for ${each.key}"
   authentication_type = "TOKEN"
   sharing_code        = random_password.db2opensharecode[each.key].result
 }
 
-resource "databricks_share" "ext_schema_share" {
+resource "databricks_share" "ext_table_share" {
   provider = databricks.workspace
 
-  name = var.external_share_name
-  object {
-    name                        = var.schema_name_silver_ext
-    data_object_type            = "SCHEMA"
-    history_data_sharing_status = "ENABLED"
+  name = var.share_name
+
+  dynamic "object" {
+    for_each = var.tables_to_share
+    content {
+      name                        = "${var.schema_name_ext}.${object.value}"
+      data_object_type            = "TABLE"
+      history_data_sharing_status = "ENABLED"
+    }
   }
 }
 
 resource "databricks_grants" "share_grants" {
   provider = databricks.workspace
-  share    = databricks_share.ext_schema_share.name
+  share    = databricks_share.ext_table_share.name
+
+  count = length(databricks_recipient.db2open) > 0 ? 1 : 0
 
   dynamic "grant" {
     for_each = databricks_recipient.db2open

--- a/terraform/modules/db2open/main.tf
+++ b/terraform/modules/db2open/main.tf
@@ -1,0 +1,41 @@
+resource "random_password" "db2opensharecode" {
+  for_each = var.consumer_org_numbers
+
+  length  = 16
+  special = true
+}
+
+resource "databricks_recipient" "db2open" {
+  provider = databricks.workspace
+
+  for_each = var.consumer_org_numbers
+
+  name                = "recipient_${each.key}"
+  comment             = "Recipient av sb2open opprettet i Terraform for ${each.key}"
+  authentication_type = "TOKEN"
+  sharing_code        = random_password.db2opensharecode[each.key].result
+}
+
+resource "databricks_share" "ext_schema_share" {
+  provider = databricks.workspace
+
+  name = var.external_share_name
+  object {
+    name                        = var.schema_name_silver_ext
+    data_object_type            = "SCHEMA"
+    history_data_sharing_status = "ENABLED"
+  }
+}
+
+resource "databricks_grants" "share_grants" {
+  provider = databricks.workspace
+  share    = databricks_share.ext_schema_share.name
+
+  dynamic "grant" {
+    for_each = databricks_recipient.db2open
+    content {
+      principal  = grant.value.name
+      privileges = ["SELECT"]
+    }
+  }
+}

--- a/terraform/modules/db2open/outputs.tf
+++ b/terraform/modules/db2open/outputs.tf
@@ -7,21 +7,30 @@ output "delta_sharing_config_urls" {
   description = "URLs to download the Delta Sharing configuration for each recipient."
 }
 
+output "databricks_recipient_names" {
+  value = {
+    for key, recipient in databricks_recipient.db2open :
+    key => recipient.name
+  }
+  description = "Mapping of Databricks recipients."
+}
+
+# Sensitive output containing tokens and sharing codes
 output "databricks_recipient_data" {
   value = {
     for key, recipient in databricks_recipient.db2open :
     key => {
-      name           = recipient.name
       tokens         = recipient.tokens
       sharing_code   = recipient.sharing_code
       activation_url = try(recipient.tokens[0].activation_url, "No activation URL available")
     }
   }
   sensitive   = true
-  description = "Data for each Databricks recipient, including activation URLs and sharing codes."
+  description = "Data for each Databricks recipient."
 }
 
+
 output "external_share_name" {
-  value       = databricks_share.ext_schema_share.name
+  value       = databricks_share.ext_table_share
   description = "The name of the external share."
 }

--- a/terraform/modules/db2open/outputs.tf
+++ b/terraform/modules/db2open/outputs.tf
@@ -1,36 +1,26 @@
-output "delta_sharing_config_urls" {
-  value = {
-    for key, recipient in databricks_recipient.db2open :
-    key => recipient.tokens[0].activation_url
-  }
+output "delta_sharing_config_url" {
+  value       = var.recipient != "" ? databricks_recipient.db2open[0].tokens[0].activation_url : null
   sensitive   = true
-  description = "URLs to download the Delta Sharing configuration for each recipient."
+  description = "URL to download the Delta Sharing configuration for the recipient."
 }
 
-output "databricks_recipient_names" {
-  value = {
-    for key, recipient in databricks_recipient.db2open :
-    key => recipient.name
-  }
-  description = "Mapping of Databricks recipients."
+output "databricks_recipient_name" {
+  value       = var.recipient != "" ? databricks_recipient.db2open[0].name : null
+  description = "Name of the Databricks recipient."
 }
 
 # Sensitive output containing tokens and sharing codes
 output "databricks_recipient_data" {
-  value = {
-    for key, recipient in databricks_recipient.db2open :
-    key => {
-      tokens         = recipient.tokens
-      sharing_code   = recipient.sharing_code
-      activation_url = try(recipient.tokens[0].activation_url, "No activation URL available")
-    }
-  }
+  value = var.recipient != "" ? {
+    tokens         = databricks_recipient.db2open[0].tokens
+    sharing_code   = databricks_recipient.db2open[0].sharing_code
+    activation_url = try(databricks_recipient.db2open[0].tokens[0].activation_url, "No activation URL available")
+  } : null
   sensitive   = true
-  description = "Data for each Databricks recipient."
+  description = "Data for the Databricks recipient."
 }
 
-
 output "external_share_name" {
-  value       = databricks_share.ext_table_share
+  value       = databricks_share.ext_table_share.name
   description = "The name of the external share."
 }

--- a/terraform/modules/db2open/outputs.tf
+++ b/terraform/modules/db2open/outputs.tf
@@ -1,0 +1,27 @@
+output "delta_sharing_config_urls" {
+  value = {
+    for key, recipient in databricks_recipient.db2open :
+    key => recipient.tokens[0].activation_url
+  }
+  sensitive   = true
+  description = "URLs to download the Delta Sharing configuration for each recipient."
+}
+
+output "databricks_recipient_data" {
+  value = {
+    for key, recipient in databricks_recipient.db2open :
+    key => {
+      name           = recipient.name
+      tokens         = recipient.tokens
+      sharing_code   = recipient.sharing_code
+      activation_url = try(recipient.tokens[0].activation_url, "No activation URL available")
+    }
+  }
+  sensitive   = true
+  description = "Data for each Databricks recipient, including activation URLs and sharing codes."
+}
+
+output "external_share_name" {
+  value       = databricks_share.ext_schema_share.name
+  description = "The name of the external share."
+}

--- a/terraform/modules/db2open/variables.tf
+++ b/terraform/modules/db2open/variables.tf
@@ -1,13 +1,19 @@
-variable "consumer_org_numbers" {
-  description = "List of valid consumer organization numbers."
+variable "recipients" {
+  description = "List of valid recipient organization numbers."
 }
 
-variable "schema_name_silver_ext" {
+variable "schema_name_ext" {
   type        = string
   description = "The schema name to share."
 }
 
-variable "external_share_name" {
-  description = "Name of share for external schema"
+variable "tables_to_share" {
+  type        = list(string)
+  default     = []
+  description = "List of tables to share"
+}
+
+variable "share_name" {
+  description = "Name of share"
   type        = string
 }

--- a/terraform/modules/db2open/variables.tf
+++ b/terraform/modules/db2open/variables.tf
@@ -1,4 +1,4 @@
-variable "recipients" {
+variable "recipient" {
   description = "List of valid recipient organization numbers."
 }
 

--- a/terraform/modules/db2open/variables.tf
+++ b/terraform/modules/db2open/variables.tf
@@ -1,0 +1,13 @@
+variable "consumer_org_numbers" {
+  description = "List of valid consumer organization numbers."
+}
+
+variable "schema_name_silver_ext" {
+  type        = string
+  description = "The schema name to share."
+}
+
+variable "external_share_name" {
+  description = "Name of share for external schema"
+  type        = string
+}


### PR DESCRIPTION
Modul for å opprette shares, recipients og grant i delta share på tabellnivå. 

Outputs
Databricks recipient name (ikke sensitiv så vi kan iterere over når vi lagrer datta i GCP bøtta)
Databricks recipient data (sensitiv men brukes for å lese og skrive aktiverings url ved initiering)

**Oppdatert bruk**: 
Slik bruker vi modulen hos oss. Dette gjør at vi eksplisitt definerer tabeller, som vi kobler opp mot recipients. 
```
module "databricks_delta_share_byggning_bruksenhet_etasjer_tables" {
  source = "./modules/db2open"

  recipients      = var.consumer_byggning_bruksenhet_etasjer_tables
  schema_name_ext = var.schema_name_silver_ext
  share_name      = "byggning_bruksenhet_etasjer_${var.environment}"
  tables_to_share = local.byggning_bruksenhet_etasjer_tables

  providers = {
    databricks.workspace = databricks.workspace
  }
}


resource "google_storage_bucket_object" "recipient_auth_links_byggning_bruksenhet_etasjer_tables" {
  for_each = module.databricks_delta_share_byggning_bruksenhet_etasjer_tables.databricks_recipient_names

  bucket = module.skyporten_integration_setup.gcs_bucket_names[each.key]
  name   = "${module.databricks_delta_share_byggning_bruksenhet_etasjer_tables.databricks_recipient_names[each.key]}.json"

  content = jsonencode({
    authentication_link = try(
      module.databricks_delta_share_byggning_bruksenhet_etasjer_tables.databricks_recipient_data[each.key].activation_url,
      "No activation URL available"
    )
  })

  content_type = "application/json"
}
```
