### PR TITLE
Ny IAM binding på bøtte

### DIFF
--- a/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
+++ b/terraform/modules/skyporten_workload_identity/skyporten_consumers/main.tf
@@ -8,30 +8,26 @@ resource "random_string" "random" {
   upper   = false
 }
 
-data "google_iam_policy" "client_access" {
-  binding {
-    role = "roles/storage.legacyBucketReader"
+resource "google_storage_bucket_iam_binding" "client_legacy_reader" {
+  bucket = google_storage_bucket.skyporten_bucket.name
+  role   = "roles/storage.legacyBucketReader"
 
-    members = [
-      "principalSet://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/attribute.clientaccess/client::${var.maskinporten_client_id}::${local.maskinporten_scope}",
-    ]
-  }
-  binding {
-    role = "roles/storage.objectViewer"
+  members = [
+    "principalSet://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/attribute.clientaccess/client::${var.maskinporten_client_id}::${local.maskinporten_scope}",
+  ]
+}
 
-    members = [
-      "principalSet://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/attribute.clientaccess/client::${var.maskinporten_client_id}::${local.maskinporten_scope}",
-    ]
-  }
+resource "google_storage_bucket_iam_binding" "client_object_viewer" {
+  bucket = google_storage_bucket.skyporten_bucket.name
+  role   = "roles/storage.objectViewer"
+
+  members = [
+    "principalSet://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/attribute.clientaccess/client::${var.maskinporten_client_id}::${local.maskinporten_scope}",
+  ]
 }
 
 resource "google_storage_bucket" "skyporten_bucket" {
   name                        = "sp-${var.project_id}-${random_string.random.result}"
   location                    = var.region
   uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket_iam_policy" "client_access_to_bucket" {
-  bucket      = google_storage_bucket.skyporten_bucket.name
-  policy_data = data.google_iam_policy.client_access.policy_data
 }


### PR DESCRIPTION
Bruker vi `google_storage_bucket_iam_binding` istedenfor `google_storage_bucket_iam_policy`, slipper vi å overskrive eventuelle eksisterende policies på bøtta. I tillegg kan vi definere IAM direkte på bøtta istedenfor i to steg