### PR TITLE
Fjern PAT og erstatt med octo-sts

### DIFF
--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -27,10 +27,6 @@ on:
                 required: false
                 type: boolean
                 default: false
-            identity:
-                description: "The identity (repo name) to use for creating octo-sts token"
-                required: true
-                type: string
 
 env:
     DEBUG_MODE: ${{ inputs.debug_mode }}
@@ -38,7 +34,6 @@ env:
     REPO_NAME: ${{ inputs.project_name }}-data-ingestor
     AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
     SERVICE_ACCOUNT: ${{ inputs.service_account }}
-    IDENTITY: ${{ inputs.identity }}
 
 jobs:
     create_and_clone_repo:
@@ -48,7 +43,7 @@ jobs:
               id: octo-sts
               with:
                   scope: kartverket/${{ env.REPO_NAME }}
-                  identity: ${{ env.IDENTITY }}
+                  identity: "dask-modules"
 
             - name: Create empty repo
               if: env.DEBUG_MODE == 'false'

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -30,7 +30,7 @@ on:
 
 env:
     DEBUG_MODE: ${{ inputs.debug_mode }}
-    TEAM_NAME: ${{ inputs.team_name }} # Lowercase-name-for-team
+    TEAM_NAME: ${{ inputs.team_name }}
     REPO_NAME: ${{ inputs.project_name }}-data-ingestor
     AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
     SERVICE_ACCOUNT: ${{ inputs.service_account }}
@@ -41,54 +41,66 @@ jobs:
         permissions:
             id-token: write
         steps:
-            - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
-              id: octo-sts
+            - name: Generate GitHub App token
+              id: github_app
+              uses: tibdex/github-app-token@v2
               with:
-                  scope: kartverket/dask-monorepo-reference-setup
-                  identity: "dask-modules"
+                  app_id: ${{ secrets.GH_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
             - name: Create empty repo
               if: env.DEBUG_MODE == 'false'
               uses: actions/github-script@v7
               with:
-                  github-token: ${{ steps.octo-sts.outputs.token }}
+                  github-token: ${{ steps.github_app.outputs.token }}
                   script: |
                       const repoName = '${{ env.REPO_NAME }}';
-                      const response = await github.request('POST /orgs/{org}/repos', {
-                          org: 'kartverket',
-                          name: repoName,
-                          description: 'This is your first repository',
-                          visibility: 'internal',
-                          headers: {
-                            'X-GitHub-Api-Version': '2022-11-28'
-                          }
+                      const response = await github.rest.repos.createInOrg({
+                        org: 'kartverket',
+                        name: repoName,
+                        description: 'Repo created by DASK workflow',
+                        private: true,
+                        auto_init: false
                       });
-                      console.log(`Response for creating repo ${repoName}:`, response);
+                      console.log(`Created repo ${repoName}:`, response.status);
+
             - name: Set DASK group as admin
               if: env.DEBUG_MODE == 'false'
               uses: actions/github-script@v7
               with:
-                  github-token: ${{ steps.octo-sts.outputs.token }}
+                  github-token: ${{ steps.github_app.outputs.token }}
                   script: |
                       const repoName = '${{ env.REPO_NAME }}';
                       const teamSlug = 'dask';
-                      const response = await github.request('PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}', {
+                      const response = await github.rest.teams.addOrUpdateRepoPermissionsInOrg({
                         org: 'kartverket',
                         team_slug: teamSlug,
                         owner: 'kartverket',
                         repo: repoName,
-                        permission: 'admin',
-                        headers: {
-                          'X-GitHub-Api-Version': '2022-11-28'
-                        }
+                        permission: 'admin'
                       });
-                      console.log(`Response for adding DASK group as admin on repo ${repoName}:`, response);
+                      console.log(`Added DASK team to ${repoName}:`, response.status);
+
+            - name: Get octo-sts token for the template repo
+              uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
+              id: octo-sts-template
+              with:
+                  scope: kartverket/dask-monorepo-reference-setup
+                  identity: "dask-modules"
+
             - name: Checkout the reference repository
               uses: actions/checkout@v4
               with:
                   repository: kartverket/dask-monorepo-reference-setup
                   ref: main
-                  token: ${{ steps.octo-sts.outputs.token }}
+                  token: ${{ steps.octo-sts-template.outputs.token }}
+
+            - name: Get octo-sts token for the new repo
+              uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
+              id: octo-sts-new
+              with:
+                  scope: kartverket/${{ env.REPO_NAME }}
+                  identity: "dask-modules"
 
             - name: Push to a new branch
               if: env.DEBUG_MODE == 'false'
@@ -100,9 +112,7 @@ jobs:
                   git add .
                   git commit -m "Initial commit"
                   git branch -M main
-                  git remote add origin https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com/kartverket/${{ env.REPO_NAME }}.git
-                  echo "git status: $(git status)"
-                  echo "git push"
+                  git remote add origin https://x-access-token:${{ steps.octo-sts-new.outputs.token }}@github.com/kartverket/${{ env.REPO_NAME }}.git
                   git push -u origin main
 
     send_success_message_to_pubsub:

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -1,111 +1,121 @@
 name: Create empty GitHub repo and clone monorepo into it
 
 on:
-  workflow_dispatch:
-    inputs:
-      team_name:
-        description: "The team name"
-        required: true
-        type: string
-      project_name:
-        description: "The project name used to create the data-ingestor repo"
-        required: true
-        type: string
-      service_account:
-        description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
-        required: true
-        type: string
-      auth_project_number:
-        description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
-        required: true
-        type: string
-      script_params:
-        description: "Parameters to use in the script"
-        required: false
-      debug_mode:
-        description: "If the workflow should actually create resources or just run through without doing so."
-        required: false
-        type: boolean
-        default: false
+    workflow_dispatch:
+        inputs:
+            team_name:
+                description: "The team name"
+                required: true
+                type: string
+            project_name:
+                description: "The project name used to create the data-ingestor repo"
+                required: true
+                type: string
+            service_account:
+                description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
+                required: true
+                type: string
+            auth_project_number:
+                description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
+                required: true
+                type: string
+            script_params:
+                description: "Parameters to use in the script"
+                required: false
+            debug_mode:
+                description: "If the workflow should actually create resources or just run through without doing so."
+                required: false
+                type: boolean
+                default: false
+            identity:
+                description: "The identity (repo name) to use for creating octo-sts token"
+                required: true
+                type: string
 
 env:
-  GITHUB_TOKEN: ${{ secrets.DASK_ONBOARDING_PAT }}
-  DEBUG_MODE: ${{ inputs.debug_mode }}
-  TEAM_NAME: ${{ inputs.team_name }} # Lowercase-name-for-team
-  REPO_NAME: ${{ inputs.project_name }}-data-ingestor
-  AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
-  SERVICE_ACCOUNT: ${{ inputs.service_account }}
+    DEBUG_MODE: ${{ inputs.debug_mode }}
+    TEAM_NAME: ${{ inputs.team_name }} # Lowercase-name-for-team
+    REPO_NAME: ${{ inputs.project_name }}-data-ingestor
+    AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
+    SERVICE_ACCOUNT: ${{ inputs.service_account }}
+    IDENTITY: ${{ inputs.identity }}
 
 jobs:
-  create_and_clone_repo:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create empty repo
-        if: env.DEBUG_MODE == 'false'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ env.GITHUB_TOKEN }}
-          script: |
-            const repoName = '${{ env.REPO_NAME }}';
-            const response = await github.request('POST /orgs/{org}/repos', {
-                org: 'kartverket',
-                name: repoName,
-                description: 'This is your first repository',
-                visibility: 'internal',
-                headers: {
-                  'X-GitHub-Api-Version': '2022-11-28'
-                }
-            });
-            console.log(`Response for creating repo ${repoName}:`, response);
-      - name: Set DASK group as admin
-        if: env.DEBUG_MODE == 'false'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ env.GITHUB_TOKEN }}
-          script: |
-            const repoName = '${{ env.REPO_NAME }}';
-            const teamSlug = 'dask';
-            const response = await github.request('PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}', {
-              org: 'kartverket',
-              team_slug: teamSlug,
-              owner: 'kartverket',
-              repo: repoName,
-              permission: 'admin',
-              headers: {
-                'X-GitHub-Api-Version': '2022-11-28'
-              }
-            });
-            console.log(`Response for adding DASK group as admin on repo ${repoName}:`, response);
-      - name: Checkout the reference repository
-        uses: actions/checkout@v4
-        with:
-          repository: kartverket/dask-monorepo-reference-setup
-          ref: main
-          token: ${{ env.GITHUB_TOKEN }}
+    create_and_clone_repo:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
+              id: octo-sts
+              with:
+                  scope: kartverket/${{ env.REPO_NAME }}
+                  identity: ${{ env.IDENTITY }}
 
-      - name: Push to a new branch
-        if: env.DEBUG_MODE == 'false'
-        run: |
-          git config --global user.name "DASK CI"
-          git config --global user.email "noreply@kartverket.no"
-          rm -rf .git
-          git init
-          git add .
-          git commit -m "Initial commit"
-          git branch -M main
-          git remote add origin https://x-access-token:${{env.GITHUB_TOKEN}}@github.com/kartverket/${{ env.REPO_NAME }}.git
-          echo "git status: $(git status)"
-          echo "git push"
-          git push -u origin main
+            - name: Create empty repo
+              if: env.DEBUG_MODE == 'false'
+              uses: actions/github-script@v7
+              with:
+                  github-token: ${{ steps.octo-sts.outputs.token }}
+                  script: |
+                      const repoName = '${{ env.REPO_NAME }}';
+                      const response = await github.request('POST /orgs/{org}/repos', {
+                          org: 'kartverket',
+                          name: repoName,
+                          description: 'This is your first repository',
+                          visibility: 'internal',
+                          headers: {
+                            'X-GitHub-Api-Version': '2022-11-28'
+                          }
+                      });
+                      console.log(`Response for creating repo ${repoName}:`, response);
+            - name: Set DASK group as admin
+              if: env.DEBUG_MODE == 'false'
+              uses: actions/github-script@v7
+              with:
+                  github-token: ${{ steps.octo-sts.outputs.token }}
+                  script: |
+                      const repoName = '${{ env.REPO_NAME }}';
+                      const teamSlug = 'dask';
+                      const response = await github.request('PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}', {
+                        org: 'kartverket',
+                        team_slug: teamSlug,
+                        owner: 'kartverket',
+                        repo: repoName,
+                        permission: 'admin',
+                        headers: {
+                          'X-GitHub-Api-Version': '2022-11-28'
+                        }
+                      });
+                      console.log(`Response for adding DASK group as admin on repo ${repoName}:`, response);
+            - name: Checkout the reference repository
+              uses: actions/checkout@v4
+              with:
+                  repository: kartverket/dask-monorepo-reference-setup
+                  ref: main
+                  token: ${{ steps.octo-sts.outputs.token }}
 
-  send_success_message_to_pubsub:
-    needs: create_and_clone_repo
-    uses: ./.github/workflows/publish-message-pubsub.yml
-    permissions:
-      id-token: write
-    with:
-      auth_project_number: ${{ inputs.auth_project_number }}
-      service_account: ${{ inputs.service_account }}
-      team_name: ${{ inputs.team_name }}
-      params: ${{ inputs.script_params }}
-      step_id: setup-ingestor
+            - name: Push to a new branch
+              if: env.DEBUG_MODE == 'false'
+              run: |
+                  git config --global user.name "DASK CI"
+                  git config --global user.email "noreply@kartverket.no"
+                  rm -rf .git
+                  git init
+                  git add .
+                  git commit -m "Initial commit"
+                  git branch -M main
+                  git remote add origin https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com/kartverket/${{ env.REPO_NAME }}.git
+                  echo "git status: $(git status)"
+                  echo "git push"
+                  git push -u origin main
+
+    send_success_message_to_pubsub:
+        needs: create_and_clone_repo
+        uses: ./.github/workflows/publish-message-pubsub.yml
+        permissions:
+            id-token: write
+        with:
+            auth_project_number: ${{ inputs.auth_project_number }}
+            service_account: ${{ inputs.service_account }}
+            team_name: ${{ inputs.team_name }}
+            params: ${{ inputs.script_params }}
+            step_id: setup-ingestor

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -1,128 +1,128 @@
 name: Create empty GitHub repo and clone monorepo into it
 
 on:
-    workflow_dispatch:
-        inputs:
-            team_name:
-                description: "The team name"
-                required: true
-                type: string
-            project_name:
-                description: "The project name used to create the data-ingestor repo"
-                required: true
-                type: string
-            service_account:
-                description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
-                required: true
-                type: string
-            auth_project_number:
-                description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
-                required: true
-                type: string
-            script_params:
-                description: "Parameters to use in the script"
-                required: false
-            debug_mode:
-                description: "If the workflow should actually create resources or just run through without doing so."
-                required: false
-                type: boolean
-                default: false
+  workflow_dispatch:
+    inputs:
+      team_name:
+        description: "The team name"
+        required: true
+        type: string
+      project_name:
+        description: "The project name used to create the data-ingestor repo"
+        required: true
+        type: string
+      service_account:
+        description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
+        required: true
+        type: string
+      auth_project_number:
+        description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
+        required: true
+        type: string
+      script_params:
+        description: "Parameters to use in the script"
+        required: false
+      debug_mode:
+        description: "If the workflow should actually create resources or just run through without doing so."
+        required: false
+        type: boolean
+        default: false
 
 env:
-    DEBUG_MODE: ${{ inputs.debug_mode }}
-    TEAM_NAME: ${{ inputs.team_name }}
-    REPO_NAME: ${{ inputs.project_name }}-data-ingestor
-    AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
-    SERVICE_ACCOUNT: ${{ inputs.service_account }}
+  DEBUG_MODE: ${{ inputs.debug_mode }}
+  TEAM_NAME: ${{ inputs.team_name }}
+  REPO_NAME: ${{ inputs.project_name }}-data-ingestor
+  AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
+  SERVICE_ACCOUNT: ${{ inputs.service_account }}
 
 jobs:
-    create_and_clone_repo:
-        runs-on: ubuntu-latest
-        permissions:
-            id-token: write
-        steps:
-            - name: Generate GitHub App token
-              id: github_app
-              uses: tibdex/github-app-token@v2
-              with:
-                  app_id: ${{ secrets.GH_APP_ID }}
-                  private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
-            - name: Create empty repo
-              if: env.DEBUG_MODE == 'false'
-              uses: actions/github-script@v7
-              with:
-                  github-token: ${{ steps.github_app.outputs.token }}
-                  script: |
-                      const repoName = '${{ env.REPO_NAME }}';
-                      const response = await github.rest.repos.createInOrg({
-                        org: 'kartverket',
-                        name: repoName,
-                        description: 'Repo created by DASK workflow',
-                        private: true,
-                        auto_init: false
-                      });
-                      console.log(`Created repo ${repoName}:`, response.status);
-
-            - name: Set DASK group as admin
-              if: env.DEBUG_MODE == 'false'
-              uses: actions/github-script@v7
-              with:
-                  github-token: ${{ steps.github_app.outputs.token }}
-                  script: |
-                      const repoName = '${{ env.REPO_NAME }}';
-                      const teamSlug = 'dask';
-                      const response = await github.rest.teams.addOrUpdateRepoPermissionsInOrg({
-                        org: 'kartverket',
-                        team_slug: teamSlug,
-                        owner: 'kartverket',
-                        repo: repoName,
-                        permission: 'admin'
-                      });
-                      console.log(`Added DASK team to ${repoName}:`, response.status);
-
-            - name: Get octo-sts token for the template repo
-              uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
-              id: octo-sts-template
-              with:
-                  scope: kartverket/dask-monorepo-reference-setup
-                  identity: "dask-modules"
-
-            - name: Checkout the reference repository
-              uses: actions/checkout@v4
-              with:
-                  repository: kartverket/dask-monorepo-reference-setup
-                  ref: main
-                  token: ${{ steps.octo-sts-template.outputs.token }}
-
-            - name: Get octo-sts token for the new repo
-              uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
-              id: octo-sts-new
-              with:
-                  scope: kartverket/${{ env.REPO_NAME }}
-                  identity: "dask-modules"
-
-            - name: Push to a new branch
-              if: env.DEBUG_MODE == 'false'
-              run: |
-                  git config --global user.name "DASK CI"
-                  git config --global user.email "noreply@kartverket.no"
-                  rm -rf .git
-                  git init
-                  git add .
-                  git commit -m "Initial commit"
-                  git branch -M main
-                  git remote add origin https://x-access-token:${{ steps.octo-sts-new.outputs.token }}@github.com/kartverket/${{ env.REPO_NAME }}.git
-                  git push -u origin main
-
-    send_success_message_to_pubsub:
-        needs: create_and_clone_repo
-        uses: ./.github/workflows/publish-message-pubsub.yml
-        permissions:
-            id-token: write
+  create_and_clone_repo:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Generate GitHub App token
+        id: github_app
+        uses: tibdex/github-app-token@v2
         with:
-            auth_project_number: ${{ inputs.auth_project_number }}
-            service_account: ${{ inputs.service_account }}
-            team_name: ${{ inputs.team_name }}
-            params: ${{ inputs.script_params }}
-            step_id: setup-ingestor
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Create empty repo
+        if: env.DEBUG_MODE == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.github_app.outputs.token }}
+          script: |
+            const repoName = '${{ env.REPO_NAME }}';
+            const response = await github.rest.repos.createInOrg({
+              org: 'kartverket',
+              name: repoName,
+              description: 'Repo created by DASK workflow',
+              private: true,
+              auto_init: false
+            });
+            console.log(`Created repo ${repoName}:`, response.status);
+
+      - name: Set DASK group as admin
+        if: env.DEBUG_MODE == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.github_app.outputs.token }}
+          script: |
+            const repoName = '${{ env.REPO_NAME }}';
+            const teamSlug = 'dask';
+            const response = await github.rest.teams.addOrUpdateRepoPermissionsInOrg({
+              org: 'kartverket',
+              team_slug: teamSlug,
+              owner: 'kartverket',
+              repo: repoName,
+              permission: 'admin'
+            });
+            console.log(`Added DASK team to ${repoName}:`, response.status);
+
+      - name: Get octo-sts token for the template repo
+        uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
+        id: octo-sts-template
+        with:
+          scope: kartverket/dask-monorepo-reference-setup
+          identity: "dask-modules"
+
+      - name: Checkout the reference repository
+        uses: actions/checkout@v4
+        with:
+          repository: kartverket/dask-monorepo-reference-setup
+          ref: main
+          token: ${{ steps.octo-sts-template.outputs.token }}
+
+      - name: Get octo-sts token for the new repo
+        uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
+        id: octo-sts-new
+        with:
+          scope: kartverket/${{ env.REPO_NAME }}
+          identity: "dask-modules"
+
+      - name: Push to a new branch
+        if: env.DEBUG_MODE == 'false'
+        run: |
+          git config --global user.name "DASK CI"
+          git config --global user.email "noreply@kartverket.no"
+          rm -rf .git
+          git init
+          git add .
+          git commit -m "Initial commit"
+          git branch -M main
+          git remote add origin https://x-access-token:${{ steps.octo-sts-new.outputs.token }}@github.com/kartverket/${{ env.REPO_NAME }}.git
+          git push -u origin main
+
+  send_success_message_to_pubsub:
+    needs: create_and_clone_repo
+    uses: ./.github/workflows/publish-message-pubsub.yml
+    permissions:
+      id-token: write
+    with:
+      auth_project_number: ${{ inputs.auth_project_number }}
+      service_account: ${{ inputs.service_account }}
+      team_name: ${{ inputs.team_name }}
+      params: ${{ inputs.script_params }}
+      step_id: setup-ingestor

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -72,14 +72,17 @@ jobs:
           script: |
             const repoName = '${{ env.REPO_NAME }}';
             const teamSlug = 'dask';
-            const response = await github.rest.teams.addOrUpdateRepoPermissionsInOrg({
+            const response = await github.request('PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}', {
               org: 'kartverket',
               team_slug: teamSlug,
               owner: 'kartverket',
               repo: repoName,
-              permission: 'admin'
+              permission: 'admin',
+              headers: {
+                'X-GitHub-Api-Version': '2022-11-28'
+              }
             });
-            console.log(`Added DASK team to ${repoName}:`, response.status);
+            console.log(`Response for adding DASK group as admin on repo ${repoName}:`, response);
 
       - name: Get octo-sts token for the template repo
         uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -112,7 +112,7 @@ jobs:
           git add .
           git commit -m "Initial commit"
           git branch -M main
-          git remote add origin https://x-access-token:${{ steps.octo-sts-new.outputs.token }}@github.com/kartverket/${{ env.REPO_NAME }}.git
+          git remote add origin https://x-access-token:${{ steps.github_app.outputs.token }}@github.com/kartverket/${{ env.REPO_NAME }}.git
           git push -u origin main
 
   send_success_message_to_pubsub:

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -42,7 +42,7 @@ jobs:
             - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
               id: octo-sts
               with:
-                  scope: kartverket/${{ env.REPO_NAME }}
+                  scope: kartverket/dask-monorepo-reference-setup
                   identity: "dask-modules"
 
             - name: Create empty repo

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -48,21 +48,21 @@ jobs:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
-      # - name: Create empty repo
-      #   if: env.DEBUG_MODE == 'false'
-      #   uses: actions/github-script@v7
-      #   with:
-      #     github-token: ${{ steps.github_app.outputs.token }}
-      #     script: |
-      #       const repoName = '${{ env.REPO_NAME }}';
-      #       const response = await github.rest.repos.createInOrg({
-      #         org: 'kartverket',
-      #         name: repoName,
-      #         description: 'Repo created by DASK workflow',
-      #         private: true,
-      #         auto_init: false
-      #       });
-      #       console.log(`Created repo ${repoName}:`, response.status);
+      - name: Create empty repo
+        if: env.DEBUG_MODE == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.github_app.outputs.token }}
+          script: |
+            const repoName = '${{ env.REPO_NAME }}';
+            const response = await github.rest.repos.createInOrg({
+              org: 'kartverket',
+              name: repoName,
+              description: 'Repo created by DASK workflow',
+              private: true,
+              auto_init: false
+            });
+            console.log(`Created repo ${repoName}:`, response.status);
 
       - name: Set DASK group as admin
         if: env.DEBUG_MODE == 'false'

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -48,21 +48,21 @@ jobs:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
-      - name: Create empty repo
-        if: env.DEBUG_MODE == 'false'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ steps.github_app.outputs.token }}
-          script: |
-            const repoName = '${{ env.REPO_NAME }}';
-            const response = await github.rest.repos.createInOrg({
-              org: 'kartverket',
-              name: repoName,
-              description: 'Repo created by DASK workflow',
-              private: true,
-              auto_init: false
-            });
-            console.log(`Created repo ${repoName}:`, response.status);
+      # - name: Create empty repo
+      #   if: env.DEBUG_MODE == 'false'
+      #   uses: actions/github-script@v7
+      #   with:
+      #     github-token: ${{ steps.github_app.outputs.token }}
+      #     script: |
+      #       const repoName = '${{ env.REPO_NAME }}';
+      #       const response = await github.rest.repos.createInOrg({
+      #         org: 'kartverket',
+      #         name: repoName,
+      #         description: 'Repo created by DASK workflow',
+      #         private: true,
+      #         auto_init: false
+      #       });
+      #       console.log(`Created repo ${repoName}:`, response.status);
 
       - name: Set DASK group as admin
         if: env.DEBUG_MODE == 'false'
@@ -72,17 +72,14 @@ jobs:
           script: |
             const repoName = '${{ env.REPO_NAME }}';
             const teamSlug = 'dask';
-            const response = await github.request('PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}', {
+            const response = await github.rest.teams.addOrUpdateRepoPermissionsInOrg({
               org: 'kartverket',
               team_slug: teamSlug,
               owner: 'kartverket',
               repo: repoName,
-              permission: 'admin',
-              headers: {
-                'X-GitHub-Api-Version': '2022-11-28'
-              }
+              permission: 'admin'
             });
-            console.log(`Response for adding DASK group as admin on repo ${repoName}:`, response);
+            console.log(`Added DASK team to ${repoName}:`, response.status);
 
       - name: Get octo-sts token for the template repo
         uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -55,14 +55,16 @@ jobs:
           github-token: ${{ steps.github_app.outputs.token }}
           script: |
             const repoName = '${{ env.REPO_NAME }}';
-            const response = await github.rest.repos.createInOrg({
-              org: 'kartverket',
-              name: repoName,
-              description: 'Repo created by DASK workflow',
-              private: true,
-              auto_init: false
+            const response = await github.request('POST /orgs/{org}/repos', {
+                org: 'kartverket',
+                name: repoName,
+                description: 'This is your first repository',
+                visibility: 'internal',
+                headers: {
+                  'X-GitHub-Api-Version': '2022-11-28'
+                }
             });
-            console.log(`Created repo ${repoName}:`, response.status);
+            console.log(`Response for creating repo ${repoName}:`, response);
 
       - name: Set DASK group as admin
         if: env.DEBUG_MODE == 'false'

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -38,6 +38,8 @@ env:
 jobs:
     create_and_clone_repo:
         runs-on: ubuntu-latest
+        permissions:
+            id-token: write
         steps:
             - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
               id: octo-sts

--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -95,13 +95,6 @@ jobs:
           ref: main
           token: ${{ steps.octo-sts-template.outputs.token }}
 
-      - name: Get octo-sts token for the new repo
-        uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
-        id: octo-sts-new
-        with:
-          scope: kartverket/${{ env.REPO_NAME }}
-          identity: "dask-modules"
-
       - name: Push to a new branch
         if: env.DEBUG_MODE == 'false'
         run: |

--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -42,13 +42,8 @@ on:
                 description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
                 required: true
                 type: string
-            identity:
-                description: "The identity (repo name) to use for creating octo-sts token"
-                required: true
-                type: string
 
 env:
-    GITHUB_TOKEN: ${{ secrets.DASK_ONBOARDING_PAT }}
     SHOULD_CREATE_PR: ${{ inputs.should_create_pr }}
     TARGET_REPO: ${{ inputs.target_repo }}
     FILE_TO_MODIFY_PATH: ${{ inputs.file_to_modify_path }}
@@ -59,7 +54,6 @@ env:
     SERVICE_ACCOUNT: ${{ inputs.service_account }}
     TEAM_NAME: ${{ inputs.team_name }} # Lowercase-name-for-team
     PROJECT_NAME: ${{ inputs.project_name }}
-    IDENTITY: ${{ inputs.identity }}
 
 jobs:
     create_pull_request:
@@ -71,7 +65,7 @@ jobs:
               id: octo-sts
               with:
                   scope: kartverket/${{ env.TARGET_REPO }}
-                  identity: ${{ env.IDENTITY }}
+                  identity: "dask-modules"
 
             - name: Setup Terraform
               uses: hashicorp/setup-terraform@v2.0.3

--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -1,182 +1,193 @@
 name: Create pull request to repository
 
 on:
-  workflow_dispatch:
-    inputs:
-      should_create_pr:
-        description: "Should create pull request"
-        required: true
-        type: boolean
-      target_repo:
-        description: "Repository to create pull request for"
-        required: true
-        type: string
-      file_to_modify_path:
-        description: "File to modify"
-        required: true
-        type: string
-      script:
-        description: "Script to run"
-        required: true
-        type: string
-      script_params:
-        description: "Parameters to use in the script"
-        required: false
-      step_id:
-        description: "The step ID for the current step. Should match what the script does."
-        required: true
-        type: string
-      team_name:
-        description: "The team name used to create the data-ingestor repo"
-        required: true
-        type: string
-      project_name:
-        description: "The project name used to create the data-ingestor repo"
-        required: true
-        type: string
-      service_account:
-        description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
-        required: true
-        type: string
-      auth_project_number:
-        description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
-        required: true
-        type: string
+    workflow_dispatch:
+        inputs:
+            should_create_pr:
+                description: "Should create pull request"
+                required: true
+                type: boolean
+            target_repo:
+                description: "Repository to create pull request for"
+                required: true
+                type: string
+            file_to_modify_path:
+                description: "File to modify"
+                required: true
+                type: string
+            script:
+                description: "Script to run"
+                required: true
+                type: string
+            script_params:
+                description: "Parameters to use in the script"
+                required: false
+            step_id:
+                description: "The step ID for the current step. Should match what the script does."
+                required: true
+                type: string
+            team_name:
+                description: "The team name used to create the data-ingestor repo"
+                required: true
+                type: string
+            project_name:
+                description: "The project name used to create the data-ingestor repo"
+                required: true
+                type: string
+            service_account:
+                description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
+                required: true
+                type: string
+            auth_project_number:
+                description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
+                required: true
+                type: string
+            identity:
+                description: "The identity (repo name) to use for creating octo-sts token"
+                required: true
+                type: string
 
 env:
-  GITHUB_TOKEN: ${{ secrets.DASK_ONBOARDING_PAT }}
-  SHOULD_CREATE_PR: ${{ inputs.should_create_pr }}
-  TARGET_REPO: ${{ inputs.target_repo }}
-  FILE_TO_MODIFY_PATH: ${{ inputs.file_to_modify_path }}
-  SCRIPT: ${{ inputs.script }}
-  SCRIPT_PARAMS: ${{ inputs.script_params }}
-  STEP_ID: ${{ inputs.step_id }} # Must match step-id in dask-onboarding-service
-  AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
-  SERVICE_ACCOUNT: ${{ inputs.service_account }}
-  TEAM_NAME: ${{ inputs.team_name }} # Lowercase-name-for-team
-  PROJECT_NAME: ${{ inputs.project_name }}
+    GITHUB_TOKEN: ${{ secrets.DASK_ONBOARDING_PAT }}
+    SHOULD_CREATE_PR: ${{ inputs.should_create_pr }}
+    TARGET_REPO: ${{ inputs.target_repo }}
+    FILE_TO_MODIFY_PATH: ${{ inputs.file_to_modify_path }}
+    SCRIPT: ${{ inputs.script }}
+    SCRIPT_PARAMS: ${{ inputs.script_params }}
+    STEP_ID: ${{ inputs.step_id }} # Must match step-id in dask-onboarding-service
+    AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
+    SERVICE_ACCOUNT: ${{ inputs.service_account }}
+    TEAM_NAME: ${{ inputs.team_name }} # Lowercase-name-for-team
+    PROJECT_NAME: ${{ inputs.project_name }}
+    IDENTITY: ${{ inputs.identity }}
 
 jobs:
-  create_pull_request:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2.0.3
+    create_pull_request:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+        steps:
+            - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
+              id: octo-sts
+              with:
+                  scope: kartverket/${{ env.TARGET_REPO }}
+                  identity: ${{ env.IDENTITY }}
+
+            - name: Setup Terraform
+              uses: hashicorp/setup-terraform@v2.0.3
+              with:
+                  terraform_wrapper: false
+
+            - name: Set vars
+              id: set-output
+              run: |
+                  PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
+                  DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
+                  OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
+                  PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
+                  echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
+
+            - name: Authenticate with Google Cloud
+              uses: google-github-actions/auth@v1
+              with:
+                  workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+                  service_account: ${{ env.SERVICE_ACCOUNT }}
+                  export_environment_variables: true
+                  create_credentials_file: true
+
+            - name: Checkout current repository
+              uses: actions/checkout@v4
+              with:
+                  path: "current-repo"
+
+            - name: Checkout target repository
+              uses: actions/checkout@v4
+              with:
+                  repository: kartverket/${{ env.TARGET_REPO }}
+                  ref: main
+                  token: ${{ steps.octo-sts.outputs.token }}
+                  path: "target-repo"
+
+            - name: Modify files
+              working-directory: current-repo
+              run: |
+                  python scripts/${{ env.SCRIPT }} '../target-repo/${{ env.FILE_TO_MODIFY_PATH }}' '${{ env.SCRIPT_PARAMS }}'
+
+            - name: Format Terraform Files
+              if: env.SHOULD_CREATE_PR == 'true'
+              working-directory: target-repo
+              run: terraform fmt -recursive
+
+            - name: Commit and Push to target repository
+              if: env.SHOULD_CREATE_PR == 'true'
+              working-directory: target-repo
+              run: |
+                  HASH=$(date +%s | sha256sum | head -c 4)
+                  BRANCH_NAME="dask-onboarding-ci-${{ env.PROJECT_NAME }}-${HASH}"
+                  echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+                  git config --global user.name "DASK CI"
+                  git config --global user.email "noreply@kartverket.no"
+                  git checkout -b $BRANCH_NAME
+                  git add .
+                  git commit -m "Update files from DASK CI workflow"
+                  git push origin $BRANCH_NAME
+
+            - name: Create Pull Request
+              id: create_pr
+              if: env.SHOULD_CREATE_PR == 'true'
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const payload = {
+                          method: 'POST',
+                          headers: {
+                              'Authorization': `token ${{ steps.octo-sts.outputs.token }}`,
+                              'Accept': 'application/vnd.github.v3+json'
+                          },
+                          body: JSON.stringify({
+                              title: 'Add new team from DASK CI workflow',
+                              head: '${{ env.BRANCH_NAME }}',
+                              base: 'main',
+                              draft: true
+                          })
+                      };
+
+                      fetch(`https://api.github.com/repos/kartverket/${{ env.TARGET_REPO }}/pulls`, payload)
+                          .then(response => {
+                              if (!response.ok) {
+                                  throw new Error('Pull Request creation failed');
+                              }
+                              return response.json();
+                          })
+                          .then(data => {
+                              console.log('Pull Request created: ', data.url);
+                              core.setOutput('pullRequestUrl', data.url);
+                          })
+                          .catch(error => {
+                              console.error(error);
+                      });
+            - name: Publish Pull Request URL to Firestore
+              if: env.SHOULD_CREATE_PR == 'true' && steps.create_pr.outputs.pullRequestUrl && env.SCRIPT != 'entra_id_config.py'
+              working-directory: current-repo
+              run: |
+                  echo "Pull request URL: ${{ steps.create_pr.outputs.pullRequestUrl }}"
+                  pip install google-cloud-firestore
+                  python scripts/publish_to_firestore.py
+              env:
+                  GCP_PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
+                  PULL_REQUEST_URL: ${{ steps.create_pr.outputs.pullRequestUrl }}
+                  TEAM_NAME: ${{ env.TEAM_NAME }}
+                  STEP_ID: ${{ env.STEP_ID }}
+
+    send_success_message_to_pubsub:
+        needs: create_pull_request
+        uses: ./.github/workflows/publish-message-pubsub.yml
+        permissions:
+            id-token: write
         with:
-          terraform_wrapper: false
-
-      - name: Set vars
-        id: set-output
-        run: |
-          PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
-          DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
-          OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
-          PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
-          echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
-
-      - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@v1
-        with:
-          workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.SERVICE_ACCOUNT }}
-          export_environment_variables: true
-          create_credentials_file: true
-
-      - name: Checkout current repository
-        uses: actions/checkout@v4
-        with:
-          path: "current-repo"
-
-      - name: Checkout target repository
-        uses: actions/checkout@v4
-        with:
-          repository: kartverket/${{ env.TARGET_REPO }}
-          ref: main
-          token: ${{ env.GITHUB_TOKEN }}
-          path: "target-repo"
-
-      - name: Modify files
-        working-directory: current-repo
-        run: |
-          python scripts/${{ env.SCRIPT }} '../target-repo/${{ env.FILE_TO_MODIFY_PATH }}' '${{ env.SCRIPT_PARAMS }}'
-
-      - name: Format Terraform Files
-        if: env.SHOULD_CREATE_PR == 'true'
-        working-directory: target-repo
-        run: terraform fmt -recursive
-
-      - name: Commit and Push to target repository
-        if: env.SHOULD_CREATE_PR == 'true'
-        working-directory: target-repo
-        run: |
-          HASH=$(date +%s | sha256sum | head -c 4)
-          BRANCH_NAME="dask-onboarding-ci-${{ env.PROJECT_NAME }}-${HASH}"
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-
-          git config --global user.name "DASK CI"
-          git config --global user.email "noreply@kartverket.no"
-          git checkout -b $BRANCH_NAME
-          git add .
-          git commit -m "Update files from DASK CI workflow"
-          git push origin $BRANCH_NAME
-
-      - name: Create Pull Request
-        id: create_pr
-        if: env.SHOULD_CREATE_PR == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const payload = {
-                method: 'POST',
-                headers: {
-                    'Authorization': `token ${{ env.GITHUB_TOKEN }}`,
-                    'Accept': 'application/vnd.github.v3+json'
-                },
-                body: JSON.stringify({
-                    title: 'Add new team from DASK CI workflow',
-                    head: '${{ env.BRANCH_NAME }}',
-                    base: 'main',
-                    draft: true
-                })
-            };
-
-            fetch(`https://api.github.com/repos/kartverket/${{ env.TARGET_REPO }}/pulls`, payload)
-                .then(response => {
-                    if (!response.ok) {
-                        throw new Error('Pull Request creation failed');
-                    }
-                    return response.json();
-                })
-                .then(data => {
-                    console.log('Pull Request created: ', data.url);
-                    core.setOutput('pullRequestUrl', data.url);
-                })
-                .catch(error => {
-                    console.error(error);
-            });
-      - name: Publish Pull Request URL to Firestore
-        if: env.SHOULD_CREATE_PR == 'true' && steps.create_pr.outputs.pullRequestUrl && env.SCRIPT != 'entra_id_config.py'
-        working-directory: current-repo
-        run: |
-          echo "Pull request URL: ${{ steps.create_pr.outputs.pullRequestUrl }}"
-          pip install google-cloud-firestore
-          python scripts/publish_to_firestore.py
-        env:
-          GCP_PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
-          PULL_REQUEST_URL: ${{ steps.create_pr.outputs.pullRequestUrl }}
-          TEAM_NAME: ${{ env.TEAM_NAME }}
-          STEP_ID: ${{ env.STEP_ID }}
-
-  send_success_message_to_pubsub:
-    needs: create_pull_request
-    uses: ./.github/workflows/publish-message-pubsub.yml
-    permissions:
-      id-token: write
-    with:
-      auth_project_number: ${{ inputs.auth_project_number }}
-      service_account: ${{ inputs.service_account }}
-      team_name: ${{ inputs.team_name }}
-      step_id: ${{ inputs.step_id }}
-      params: ${{ inputs.script_params }}
+            auth_project_number: ${{ inputs.auth_project_number }}
+            service_account: ${{ inputs.service_account }}
+            team_name: ${{ inputs.team_name }}
+            step_id: ${{ inputs.step_id }}
+            params: ${{ inputs.script_params }}

--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -127,6 +127,12 @@ jobs:
                   git commit -m "Update files from DASK CI workflow"
                   git push origin $BRANCH_NAME
 
+            - name: Test token with simple API call
+              run: |
+                  curl -H "Authorization: token ${{ steps.octo-sts.outputs.token }}" \
+                        -H "Accept: application/vnd.github.v3+json" \
+                        https://api.github.com/repos/kartverket/dask-infrastructure
+
             - name: Create Pull Request
               id: create_pr
               if: env.SHOULD_CREATE_PR == 'true'

--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -112,12 +112,6 @@ jobs:
               working-directory: target-repo
               run: terraform fmt -recursive
 
-            - name: Test token with simple API call
-              run: |
-                  curl -H "Authorization: token ${{ steps.octo-sts.outputs.token }}" \
-                        -H "Accept: application/vnd.github.v3+json" \
-                        https://api.github.com/repos/kartverket/dask-infrastructure
-
             - name: Commit and Push to target repository
               if: env.SHOULD_CREATE_PR == 'true'
               working-directory: target-repo
@@ -138,35 +132,21 @@ jobs:
               if: env.SHOULD_CREATE_PR == 'true'
               uses: actions/github-script@v7
               with:
+                  github-token: ${{ steps.octo-sts.outputs.token }}
                   script: |
-                      const payload = {
-                          method: 'POST',
-                          headers: {
-                              'Authorization': `token ${{ steps.octo-sts.outputs.token }}`,
-                              'Accept': 'application/vnd.github.v3+json'
-                          },
-                          body: JSON.stringify({
-                              title: 'Add new team from DASK CI workflow',
-                              head: '${{ env.BRANCH_NAME }}',
-                              base: 'main',
-                              draft: true
-                          })
-                      };
 
-                      fetch(`https://api.github.com/repos/kartverket/${{ env.TARGET_REPO }}/pulls`, payload)
-                          .then(response => {
-                              if (!response.ok) {
-                                  throw new Error('Pull Request creation failed');
-                              }
-                              return response.json();
-                          })
-                          .then(data => {
-                              console.log('Pull Request created: ', data.url);
-                              core.setOutput('pullRequestUrl', data.url);
-                          })
-                          .catch(error => {
-                              console.error(error);
+                      const response = await github.rest.pulls.create({
+                        owner: 'kartverket',
+                        repo: process.env.TARGET_REPO,
+                        title: 'Add new team from DASK CI workflow',
+                        head: process.env.BRANCH_NAME,
+                        base: 'main',
+                        draft: true
                       });
+
+                      console.log('Pull Request created: ', response.data.html_url);
+                      core.setOutput('pullRequestUrl', response.data.html_url);
+
             - name: Publish Pull Request URL to Firestore
               if: env.SHOULD_CREATE_PR == 'true' && steps.create_pr.outputs.pullRequestUrl && env.SCRIPT != 'entra_id_config.py'
               working-directory: current-repo

--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -1,173 +1,173 @@
 name: Create pull request to repository
 
 on:
-    workflow_dispatch:
-        inputs:
-            should_create_pr:
-                description: "Should create pull request"
-                required: true
-                type: boolean
-            target_repo:
-                description: "Repository to create pull request for"
-                required: true
-                type: string
-            file_to_modify_path:
-                description: "File to modify"
-                required: true
-                type: string
-            script:
-                description: "Script to run"
-                required: true
-                type: string
-            script_params:
-                description: "Parameters to use in the script"
-                required: false
-            step_id:
-                description: "The step ID for the current step. Should match what the script does."
-                required: true
-                type: string
-            team_name:
-                description: "The team name used to create the data-ingestor repo"
-                required: true
-                type: string
-            project_name:
-                description: "The project name used to create the data-ingestor repo"
-                required: true
-                type: string
-            service_account:
-                description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
-                required: true
-                type: string
-            auth_project_number:
-                description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
-                required: true
-                type: string
+  workflow_dispatch:
+    inputs:
+      should_create_pr:
+        description: "Should create pull request"
+        required: true
+        type: boolean
+      target_repo:
+        description: "Repository to create pull request for"
+        required: true
+        type: string
+      file_to_modify_path:
+        description: "File to modify"
+        required: true
+        type: string
+      script:
+        description: "Script to run"
+        required: true
+        type: string
+      script_params:
+        description: "Parameters to use in the script"
+        required: false
+      step_id:
+        description: "The step ID for the current step. Should match what the script does."
+        required: true
+        type: string
+      team_name:
+        description: "The team name used to create the data-ingestor repo"
+        required: true
+        type: string
+      project_name:
+        description: "The project name used to create the data-ingestor repo"
+        required: true
+        type: string
+      service_account:
+        description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
+        required: true
+        type: string
+      auth_project_number:
+        description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
+        required: true
+        type: string
 
 env:
-    SHOULD_CREATE_PR: ${{ inputs.should_create_pr }}
-    TARGET_REPO: ${{ inputs.target_repo }}
-    FILE_TO_MODIFY_PATH: ${{ inputs.file_to_modify_path }}
-    SCRIPT: ${{ inputs.script }}
-    SCRIPT_PARAMS: ${{ inputs.script_params }}
-    STEP_ID: ${{ inputs.step_id }} # Must match step-id in dask-onboarding-service
-    AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
-    SERVICE_ACCOUNT: ${{ inputs.service_account }}
-    TEAM_NAME: ${{ inputs.team_name }} # Lowercase-name-for-team
-    PROJECT_NAME: ${{ inputs.project_name }}
+  SHOULD_CREATE_PR: ${{ inputs.should_create_pr }}
+  TARGET_REPO: ${{ inputs.target_repo }}
+  FILE_TO_MODIFY_PATH: ${{ inputs.file_to_modify_path }}
+  SCRIPT: ${{ inputs.script }}
+  SCRIPT_PARAMS: ${{ inputs.script_params }}
+  STEP_ID: ${{ inputs.step_id }} # Must match step-id in dask-onboarding-service
+  AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
+  SERVICE_ACCOUNT: ${{ inputs.service_account }}
+  TEAM_NAME: ${{ inputs.team_name }} # Lowercase-name-for-team
+  PROJECT_NAME: ${{ inputs.project_name }}
 
 jobs:
-    create_pull_request:
-        runs-on: ubuntu-latest
-        permissions:
-            id-token: write
-        steps:
-            - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
-              id: octo-sts
-              with:
-                  scope: kartverket/${{ env.TARGET_REPO }}
-                  identity: "dask-modules"
-
-            - name: Setup Terraform
-              uses: hashicorp/setup-terraform@v2.0.3
-              with:
-                  terraform_wrapper: false
-
-            - name: Set vars
-              id: set-output
-              run: |
-                  PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
-                  DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
-                  OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
-                  PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
-                  echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
-
-            - name: Authenticate with Google Cloud
-              uses: google-github-actions/auth@v1
-              with:
-                  workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
-                  service_account: ${{ env.SERVICE_ACCOUNT }}
-                  export_environment_variables: true
-                  create_credentials_file: true
-
-            - name: Checkout current repository
-              uses: actions/checkout@v4
-              with:
-                  path: "current-repo"
-
-            - name: Checkout target repository
-              uses: actions/checkout@v4
-              with:
-                  repository: kartverket/${{ env.TARGET_REPO }}
-                  ref: main
-                  token: ${{ steps.octo-sts.outputs.token }}
-                  path: "target-repo"
-
-            - name: Modify files
-              working-directory: current-repo
-              run: |
-                  python scripts/${{ env.SCRIPT }} '../target-repo/${{ env.FILE_TO_MODIFY_PATH }}' '${{ env.SCRIPT_PARAMS }}'
-
-            - name: Format Terraform Files
-              if: env.SHOULD_CREATE_PR == 'true'
-              working-directory: target-repo
-              run: terraform fmt -recursive
-
-            - name: Commit and Push to target repository
-              if: env.SHOULD_CREATE_PR == 'true'
-              working-directory: target-repo
-              run: |
-                  HASH=$(date +%s | sha256sum | head -c 4)
-                  BRANCH_NAME="dask-onboarding-ci-${{ env.PROJECT_NAME }}-${HASH}"
-                  echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-
-                  git config --global user.name "DASK CI"
-                  git config --global user.email "noreply@kartverket.no"
-                  git checkout -b $BRANCH_NAME
-                  git add .
-                  git commit -m "Update files from DASK CI workflow"
-                  git push origin $BRANCH_NAME
-
-            - name: Create Pull Request
-              id: create_pr
-              if: env.SHOULD_CREATE_PR == 'true'
-              uses: actions/github-script@v7
-              with:
-                  github-token: ${{ steps.octo-sts.outputs.token }}
-                  script: |
-
-                      const response = await github.rest.pulls.create({
-                        owner: 'kartverket',
-                        repo: process.env.TARGET_REPO,
-                        title: 'Add new team from DASK CI workflow',
-                        head: process.env.BRANCH_NAME,
-                        base: 'main',
-                        draft: true
-                      });
-
-                      console.log('Pull Request created: ', response.data.html_url);
-                      core.setOutput('pullRequestUrl', response.data.html_url);
-
-            - name: Publish Pull Request URL to Firestore
-              if: env.SHOULD_CREATE_PR == 'true' && steps.create_pr.outputs.pullRequestUrl && env.SCRIPT != 'entra_id_config.py'
-              working-directory: current-repo
-              run: |
-                  echo "Pull request URL: ${{ steps.create_pr.outputs.pullRequestUrl }}"
-                  pip install google-cloud-firestore
-                  python scripts/publish_to_firestore.py
-              env:
-                  GCP_PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
-                  PULL_REQUEST_URL: ${{ steps.create_pr.outputs.pullRequestUrl }}
-                  TEAM_NAME: ${{ env.TEAM_NAME }}
-                  STEP_ID: ${{ env.STEP_ID }}
-
-    send_success_message_to_pubsub:
-        needs: create_pull_request
-        uses: ./.github/workflows/publish-message-pubsub.yml
-        permissions:
-            id-token: write
+  create_pull_request:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
+        id: octo-sts
         with:
-            auth_project_number: ${{ inputs.auth_project_number }}
-            service_account: ${{ inputs.service_account }}
-            team_name: ${{ inputs.team_name }}
-            step_id: ${{ inputs.step_id }}
-            params: ${{ inputs.script_params }}
+          scope: kartverket/${{ env.TARGET_REPO }}
+          identity: "dask-modules"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_wrapper: false
+
+      - name: Set vars
+        id: set-output
+        run: |
+          PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
+          DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
+          OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
+          PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
+          echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+          export_environment_variables: true
+          create_credentials_file: true
+
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+        with:
+          path: "current-repo"
+
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          repository: kartverket/${{ env.TARGET_REPO }}
+          ref: main
+          token: ${{ steps.octo-sts.outputs.token }}
+          path: "target-repo"
+
+      - name: Modify files
+        working-directory: current-repo
+        run: |
+          python scripts/${{ env.SCRIPT }} '../target-repo/${{ env.FILE_TO_MODIFY_PATH }}' '${{ env.SCRIPT_PARAMS }}'
+
+      - name: Format Terraform Files
+        if: env.SHOULD_CREATE_PR == 'true'
+        working-directory: target-repo
+        run: terraform fmt -recursive
+
+      - name: Commit and Push to target repository
+        if: env.SHOULD_CREATE_PR == 'true'
+        working-directory: target-repo
+        run: |
+          HASH=$(date +%s | sha256sum | head -c 4)
+          BRANCH_NAME="dask-onboarding-ci-${{ env.PROJECT_NAME }}-${HASH}"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+          git config --global user.name "DASK CI"
+          git config --global user.email "noreply@kartverket.no"
+          git checkout -b $BRANCH_NAME
+          git add .
+          git commit -m "Update files from DASK CI workflow"
+          git push origin $BRANCH_NAME
+
+      - name: Create Pull Request
+        id: create_pr
+        if: env.SHOULD_CREATE_PR == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.octo-sts.outputs.token }}
+          script: |
+
+            const response = await github.rest.pulls.create({
+              owner: 'kartverket',
+              repo: process.env.TARGET_REPO,
+              title: 'Add new team from DASK CI workflow',
+              head: process.env.BRANCH_NAME,
+              base: 'main',
+              draft: true
+            });
+
+            console.log('Pull Request created: ', response.data.html_url);
+            core.setOutput('pullRequestUrl', response.data.html_url);
+
+      - name: Publish Pull Request URL to Firestore
+        if: env.SHOULD_CREATE_PR == 'true' && steps.create_pr.outputs.pullRequestUrl && env.SCRIPT != 'entra_id_config.py'
+        working-directory: current-repo
+        run: |
+          echo "Pull request URL: ${{ steps.create_pr.outputs.pullRequestUrl }}"
+          pip install google-cloud-firestore
+          python scripts/publish_to_firestore.py
+        env:
+          GCP_PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
+          PULL_REQUEST_URL: ${{ steps.create_pr.outputs.pullRequestUrl }}
+          TEAM_NAME: ${{ env.TEAM_NAME }}
+          STEP_ID: ${{ env.STEP_ID }}
+
+  send_success_message_to_pubsub:
+    needs: create_pull_request
+    uses: ./.github/workflows/publish-message-pubsub.yml
+    permissions:
+      id-token: write
+    with:
+      auth_project_number: ${{ inputs.auth_project_number }}
+      service_account: ${{ inputs.service_account }}
+      team_name: ${{ inputs.team_name }}
+      step_id: ${{ inputs.step_id }}
+      params: ${{ inputs.script_params }}

--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -112,6 +112,12 @@ jobs:
               working-directory: target-repo
               run: terraform fmt -recursive
 
+            - name: Test token with simple API call
+              run: |
+                  curl -H "Authorization: token ${{ steps.octo-sts.outputs.token }}" \
+                        -H "Accept: application/vnd.github.v3+json" \
+                        https://api.github.com/repos/kartverket/dask-infrastructure
+
             - name: Commit and Push to target repository
               if: env.SHOULD_CREATE_PR == 'true'
               working-directory: target-repo
@@ -126,12 +132,6 @@ jobs:
                   git add .
                   git commit -m "Update files from DASK CI workflow"
                   git push origin $BRANCH_NAME
-
-            - name: Test token with simple API call
-              run: |
-                  curl -H "Authorization: token ${{ steps.octo-sts.outputs.token }}" \
-                        -H "Accept: application/vnd.github.v3+json" \
-                        https://api.github.com/repos/kartverket/dask-infrastructure
 
             - name: Create Pull Request
               id: create_pr

--- a/.github/workflows/deploy-databricks.yml
+++ b/.github/workflows/deploy-databricks.yml
@@ -1,144 +1,144 @@
 name: Deploy Databricks notebooks
 
 on:
-  workflow_call:
-    inputs:
-      service_account:
-        description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
-        required: true
-        type: string
-      auth_project_number:
-        description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
-        required: true
-        type: string
-      runner:
-        description: "The GitHub runner to use when running the deploy. This can for example be `atkv1-dev`"
-        required: true
-        type: string
-      workload_identity_provider_override:
-        description: "The ID of the provider to use for authentication. Only used for overriding the default workload identity provider based on project number. It should be in the format of `projects/{{project}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/providers/{{workload_identity_pool_provider_id}}`"
-        required: false
-        type: string
-      project_id:
-        description: 'The GCP Project ID to use as the "active project" when running Terraform. Example 123456789987'
-        required: false
-        type: string
-      environment:
-        description: "The GitHub environment to use when deploying. See [using environments for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) for more info on this"
-        required: false
-        type: string
-      databricks_repo_path:
-        description: "The path to the repo where the notebooks are located in Databricks."
-        required: true
-        type: string
-      databricks_repo_folder:
-        description: "The folder in the Databricks workspace where the notebooks are located."
-        required: true
-        type: string
-      databricks_host:
-        description: "The host of the Databricks workspace."
-        required: true
-        type: string
-      repo_url:
-        description: "The url to the GitHub repository."
-        required: true
-        type: string
-      deploy_branch:
-        description: "The branch to use when updating the Databricks repo."
-        required: false
-        default: "main"
-        type: string
+    workflow_call:
+        inputs:
+            service_account:
+                description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
+                required: true
+                type: string
+            auth_project_number:
+                description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
+                required: true
+                type: string
+            runner:
+                description: "The GitHub runner to use when running the deploy. This can for example be `atkv1-dev`"
+                required: true
+                type: string
+            workload_identity_provider_override:
+                description: "The ID of the provider to use for authentication. Only used for overriding the default workload identity provider based on project number. It should be in the format of `projects/{{project}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/providers/{{workload_identity_pool_provider_id}}`"
+                required: false
+                type: string
+            project_id:
+                description: 'The GCP Project ID to use as the "active project" when running Terraform. Example 123456789987'
+                required: false
+                type: string
+            environment:
+                description: "The GitHub environment to use when deploying. See [using environments for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) for more info on this"
+                required: false
+                type: string
+            databricks_repo_path:
+                description: "The path to the repo where the notebooks are located in Databricks."
+                required: true
+                type: string
+            databricks_repo_folder:
+                description: "The folder in the Databricks workspace where the notebooks are located."
+                required: true
+                type: string
+            databricks_host:
+                description: "The host of the Databricks workspace."
+                required: true
+                type: string
+            repo_url:
+                description: "The url to the GitHub repository."
+                required: true
+                type: string
+            deploy_branch:
+                description: "The branch to use when updating the Databricks repo."
+                required: false
+                default: "main"
+                type: string
 
 env:
-  WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
-  AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
-  SERVICE_ACCOUNT: ${{ inputs.service_account }}
-  PROJECT_ID: ${{ inputs.project_id }}
-  ENVIRONMENT: ${{ inputs.environment }}
-  DATABRICKS_REPO_FOLDER: ${{ inputs.databricks_repo_folder }}
-  DATABRICKS_REPO_PATH: ${{ inputs.databricks_repo_path }}
-  REPO_URL: ${{ inputs.repo_url }}
-  DATABRICKS_HOST: ${{ inputs.databricks_host }}
-  DATABRICKS_DEPLOY_BRANCH: ${{ inputs.deploy_branch }}
+    WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
+    AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
+    SERVICE_ACCOUNT: ${{ inputs.service_account }}
+    PROJECT_ID: ${{ inputs.project_id }}
+    ENVIRONMENT: ${{ inputs.environment }}
+    DATABRICKS_REPO_FOLDER: ${{ inputs.databricks_repo_folder }}
+    DATABRICKS_REPO_PATH: ${{ inputs.databricks_repo_path }}
+    REPO_URL: ${{ inputs.repo_url }}
+    DATABRICKS_HOST: ${{ inputs.databricks_host }}
+    DATABRICKS_DEPLOY_BRANCH: ${{ inputs.deploy_branch }}
 
 jobs:
-  setup-env:
-    runs-on: ubuntu-latest
-    outputs:
-      workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
-    steps:
-      - name: Set vars
-        id: set-output
-        run: |
-          PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
-          DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
-          OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
-          PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
-          echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
-  deploy_databricks:
-    needs: [setup-env]
-    name: Databricks deploy to ${{ inputs.environment }}
-    runs-on: ${{ inputs.runner }}
-    environment: ${{ inputs.environment }}
+    setup-env:
+        runs-on: ubuntu-latest
+        outputs:
+            workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+        steps:
+            - name: Set vars
+              id: set-output
+              run: |
+                  PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
+                  DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
+                  OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
+                  PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
+                  echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
+    deploy_databricks:
+        needs: [setup-env]
+        name: Databricks deploy to ${{ inputs.environment }}
+        runs-on: ${{ inputs.runner }}
+        environment: ${{ inputs.environment }}
 
-    # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
-    concurrency: ${{ inputs.environment }}
+        # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
+        concurrency: ${{ inputs.environment }}
 
-    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-    defaults:
-      run:
-        shell: bash
+        # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+        defaults:
+            run:
+                shell: bash
 
-    env:
-      WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+        env:
+            WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.WORKLOAD_IDENTITY_PROVIDER }}
 
-    steps:
-      # Checkout the repository to the GitHub Actions runner
-      - name: Checkout
-        uses: actions/checkout@v4
+        steps:
+            # Checkout the repository to the GitHub Actions runner
+            - name: Checkout
+              uses: actions/checkout@v4
 
-      - id: google_auth
-        name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@v1
-        with:
-          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.SERVICE_ACCOUNT }}
-          project_id: ${{ env.PROJECT_ID }}
-          create_credentials_file: true
+            - id: google_auth
+              name: Authenticate with Google Cloud
+              uses: google-github-actions/auth@v1
+              with:
+                  workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+                  service_account: ${{ env.SERVICE_ACCOUNT }}
+                  project_id: ${{ env.PROJECT_ID }}
+                  create_credentials_file: true
 
-      - name: Get Databricks output vars
-        id: databricks-output-vars
-        run: |
-          echo "DATABRICKS_HOST=${{ env.DATABRICKS_HOST }}" >> $GITHUB_ENV
-          echo "GOOGLE_CREDENTIALS=${{ steps.google_auth.outputs.credentials_file_path }}" >> $GITHUB_ENV
-      - uses: databricks/setup-cli@main
-        name: Setup databricks CLI
-      - name: Set Databricks env variables
-        run: |
-          echo "CREDENTIAL_ID=''" >> $GITHUB_ENV
-      - name: Create git-credentials
-        run: |
-          OUTPUT=$(databricks git-credentials create gitHub --git-username $GITHUB_ACTOR --personal-access-token ${{ secrets.GITHUB_TOKEN }})
-          echo "$OUTPUT"
-          CREDENTIAL_ID=$(echo "$OUTPUT" | jq -r '.credential_id')
-          echo "CREDENTIAL_ID=$CREDENTIAL_ID" >> $GITHUB_ENV
-      - name: Check if Databricks repo exists
-        run: |
-          set +e 
-          REPO_EXISTS=$(databricks workspace list $DATABRICKS_REPO_FOLDER --output json | \
-            jq -r --arg REPO_PATH "$DATABRICKS_REPO_PATH" \
-            'if . != null then (map(select(.path == $REPO_PATH)) | if length > 0 then "true" else "false" end) else "false" end')
-          echo "REPO_EXISTS=$REPO_EXISTS" >> $GITHUB_ENV
-          set -e
-      - name: Create Databricks Repo if it does not exist
-        if: env.REPO_EXISTS == 'false'
-        run: |
-          databricks repos create ${{ env.REPO_URL }} gitHub --path ${{ env.DATABRICKS_REPO_PATH }}
-      - name: Update Databricks Repo if it exists
-        if: env.REPO_EXISTS == 'true'
-        run: |
-          databricks repos update ${{ env.DATABRICKS_REPO_PATH }} --branch "${{ env.DATABRICKS_DEPLOY_BRANCH }}"
-      - name: Delete git-credentials
-        if: always() && env.CREDENTIAL_ID != ''
-        run: |
-          databricks git-credentials delete $CREDENTIAL_ID
+            - name: Get Databricks output vars
+              id: databricks-output-vars
+              run: |
+                  echo "DATABRICKS_HOST=${{ env.DATABRICKS_HOST }}" >> $GITHUB_ENV
+                  echo "GOOGLE_CREDENTIALS=${{ steps.google_auth.outputs.credentials_file_path }}" >> $GITHUB_ENV
+            - uses: databricks/setup-cli@main
+              name: Setup databricks CLI
+            - name: Set Databricks env variables
+              run: |
+                  echo "CREDENTIAL_ID=''" >> $GITHUB_ENV
+            - name: Create git-credentials
+              run: |
+                  OUTPUT=$(databricks git-credentials create gitHub --git-username $GITHUB_ACTOR --personal-access-token ${{ secrets.GITHUB_TOKEN }})
+                  echo "$OUTPUT"
+                  CREDENTIAL_ID=$(echo "$OUTPUT" | jq -r '.credential_id')
+                  echo "CREDENTIAL_ID=$CREDENTIAL_ID" >> $GITHUB_ENV
+            - name: Check if Databricks repo exists
+              run: |
+                  set +e 
+                  REPO_EXISTS=$(databricks workspace list $DATABRICKS_REPO_FOLDER --output json | \
+                    jq -r --arg REPO_PATH "$DATABRICKS_REPO_PATH" \
+                    'if . != null then (map(select(.path == $REPO_PATH)) | if length > 0 then "true" else "false" end) else "false" end')
+                  echo "REPO_EXISTS=$REPO_EXISTS" >> $GITHUB_ENV
+                  set -e
+            - name: Create Databricks Repo if it does not exist
+              if: env.REPO_EXISTS == 'false'
+              run: |
+                  databricks repos create ${{ env.REPO_URL }} gitHub --path ${{ env.DATABRICKS_REPO_PATH }}
+            - name: Update Databricks Repo if it exists
+              if: env.REPO_EXISTS == 'true'
+              run: |
+                  databricks repos update ${{ env.DATABRICKS_REPO_PATH }} --branch "${{ env.DATABRICKS_DEPLOY_BRANCH }}"
+            - name: Delete git-credentials
+              if: always() && env.CREDENTIAL_ID != ''
+              run: |
+                  databricks git-credentials delete $CREDENTIAL_ID

--- a/.github/workflows/deploy-databricks.yml
+++ b/.github/workflows/deploy-databricks.yml
@@ -1,144 +1,144 @@
 name: Deploy Databricks notebooks
 
 on:
-    workflow_call:
-        inputs:
-            service_account:
-                description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
-                required: true
-                type: string
-            auth_project_number:
-                description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
-                required: true
-                type: string
-            runner:
-                description: "The GitHub runner to use when running the deploy. This can for example be `atkv1-dev`"
-                required: true
-                type: string
-            workload_identity_provider_override:
-                description: "The ID of the provider to use for authentication. Only used for overriding the default workload identity provider based on project number. It should be in the format of `projects/{{project}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/providers/{{workload_identity_pool_provider_id}}`"
-                required: false
-                type: string
-            project_id:
-                description: 'The GCP Project ID to use as the "active project" when running Terraform. Example 123456789987'
-                required: false
-                type: string
-            environment:
-                description: "The GitHub environment to use when deploying. See [using environments for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) for more info on this"
-                required: false
-                type: string
-            databricks_repo_path:
-                description: "The path to the repo where the notebooks are located in Databricks."
-                required: true
-                type: string
-            databricks_repo_folder:
-                description: "The folder in the Databricks workspace where the notebooks are located."
-                required: true
-                type: string
-            databricks_host:
-                description: "The host of the Databricks workspace."
-                required: true
-                type: string
-            repo_url:
-                description: "The url to the GitHub repository."
-                required: true
-                type: string
-            deploy_branch:
-                description: "The branch to use when updating the Databricks repo."
-                required: false
-                default: "main"
-                type: string
+  workflow_call:
+    inputs:
+      service_account:
+        description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
+        required: true
+        type: string
+      auth_project_number:
+        description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
+        required: true
+        type: string
+      runner:
+        description: "The GitHub runner to use when running the deploy. This can for example be `atkv1-dev`"
+        required: true
+        type: string
+      workload_identity_provider_override:
+        description: "The ID of the provider to use for authentication. Only used for overriding the default workload identity provider based on project number. It should be in the format of `projects/{{project}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/providers/{{workload_identity_pool_provider_id}}`"
+        required: false
+        type: string
+      project_id:
+        description: 'The GCP Project ID to use as the "active project" when running Terraform. Example 123456789987'
+        required: false
+        type: string
+      environment:
+        description: "The GitHub environment to use when deploying. See [using environments for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) for more info on this"
+        required: false
+        type: string
+      databricks_repo_path:
+        description: "The path to the repo where the notebooks are located in Databricks."
+        required: true
+        type: string
+      databricks_repo_folder:
+        description: "The folder in the Databricks workspace where the notebooks are located."
+        required: true
+        type: string
+      databricks_host:
+        description: "The host of the Databricks workspace."
+        required: true
+        type: string
+      repo_url:
+        description: "The url to the GitHub repository."
+        required: true
+        type: string
+      deploy_branch:
+        description: "The branch to use when updating the Databricks repo."
+        required: false
+        default: "main"
+        type: string
 
 env:
-    WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
-    AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
-    SERVICE_ACCOUNT: ${{ inputs.service_account }}
-    PROJECT_ID: ${{ inputs.project_id }}
-    ENVIRONMENT: ${{ inputs.environment }}
-    DATABRICKS_REPO_FOLDER: ${{ inputs.databricks_repo_folder }}
-    DATABRICKS_REPO_PATH: ${{ inputs.databricks_repo_path }}
-    REPO_URL: ${{ inputs.repo_url }}
-    DATABRICKS_HOST: ${{ inputs.databricks_host }}
-    DATABRICKS_DEPLOY_BRANCH: ${{ inputs.deploy_branch }}
+  WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
+  AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
+  SERVICE_ACCOUNT: ${{ inputs.service_account }}
+  PROJECT_ID: ${{ inputs.project_id }}
+  ENVIRONMENT: ${{ inputs.environment }}
+  DATABRICKS_REPO_FOLDER: ${{ inputs.databricks_repo_folder }}
+  DATABRICKS_REPO_PATH: ${{ inputs.databricks_repo_path }}
+  REPO_URL: ${{ inputs.repo_url }}
+  DATABRICKS_HOST: ${{ inputs.databricks_host }}
+  DATABRICKS_DEPLOY_BRANCH: ${{ inputs.deploy_branch }}
 
 jobs:
-    setup-env:
-        runs-on: ubuntu-latest
-        outputs:
-            workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
-        steps:
-            - name: Set vars
-              id: set-output
-              run: |
-                  PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
-                  DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
-                  OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
-                  PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
-                  echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
-    deploy_databricks:
-        needs: [setup-env]
-        name: Databricks deploy to ${{ inputs.environment }}
-        runs-on: ${{ inputs.runner }}
-        environment: ${{ inputs.environment }}
+  setup-env:
+    runs-on: ubuntu-latest
+    outputs:
+      workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+    steps:
+      - name: Set vars
+        id: set-output
+        run: |
+          PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
+          DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
+          OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
+          PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
+          echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
+  deploy_databricks:
+    needs: [setup-env]
+    name: Databricks deploy to ${{ inputs.environment }}
+    runs-on: ${{ inputs.runner }}
+    environment: ${{ inputs.environment }}
 
-        # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
-        concurrency: ${{ inputs.environment }}
+    # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
+    concurrency: ${{ inputs.environment }}
 
-        # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-        defaults:
-            run:
-                shell: bash
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
 
-        env:
-            WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+    env:
+      WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.WORKLOAD_IDENTITY_PROVIDER }}
 
-        steps:
-            # Checkout the repository to the GitHub Actions runner
-            - name: Checkout
-              uses: actions/checkout@v4
+    steps:
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v4
 
-            - id: google_auth
-              name: Authenticate with Google Cloud
-              uses: google-github-actions/auth@v1
-              with:
-                  workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
-                  service_account: ${{ env.SERVICE_ACCOUNT }}
-                  project_id: ${{ env.PROJECT_ID }}
-                  create_credentials_file: true
+      - id: google_auth
+        name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+          project_id: ${{ env.PROJECT_ID }}
+          create_credentials_file: true
 
-            - name: Get Databricks output vars
-              id: databricks-output-vars
-              run: |
-                  echo "DATABRICKS_HOST=${{ env.DATABRICKS_HOST }}" >> $GITHUB_ENV
-                  echo "GOOGLE_CREDENTIALS=${{ steps.google_auth.outputs.credentials_file_path }}" >> $GITHUB_ENV
-            - uses: databricks/setup-cli@main
-              name: Setup databricks CLI
-            - name: Set Databricks env variables
-              run: |
-                  echo "CREDENTIAL_ID=''" >> $GITHUB_ENV
-            - name: Create git-credentials
-              run: |
-                  OUTPUT=$(databricks git-credentials create gitHub --git-username $GITHUB_ACTOR --personal-access-token ${{ secrets.GITHUB_TOKEN }})
-                  echo "$OUTPUT"
-                  CREDENTIAL_ID=$(echo "$OUTPUT" | jq -r '.credential_id')
-                  echo "CREDENTIAL_ID=$CREDENTIAL_ID" >> $GITHUB_ENV
-            - name: Check if Databricks repo exists
-              run: |
-                  set +e 
-                  REPO_EXISTS=$(databricks workspace list $DATABRICKS_REPO_FOLDER --output json | \
-                    jq -r --arg REPO_PATH "$DATABRICKS_REPO_PATH" \
-                    'if . != null then (map(select(.path == $REPO_PATH)) | if length > 0 then "true" else "false" end) else "false" end')
-                  echo "REPO_EXISTS=$REPO_EXISTS" >> $GITHUB_ENV
-                  set -e
-            - name: Create Databricks Repo if it does not exist
-              if: env.REPO_EXISTS == 'false'
-              run: |
-                  databricks repos create ${{ env.REPO_URL }} gitHub --path ${{ env.DATABRICKS_REPO_PATH }}
-            - name: Update Databricks Repo if it exists
-              if: env.REPO_EXISTS == 'true'
-              run: |
-                  databricks repos update ${{ env.DATABRICKS_REPO_PATH }} --branch "${{ env.DATABRICKS_DEPLOY_BRANCH }}"
-            - name: Delete git-credentials
-              if: always() && env.CREDENTIAL_ID != ''
-              run: |
-                  databricks git-credentials delete $CREDENTIAL_ID
+      - name: Get Databricks output vars
+        id: databricks-output-vars
+        run: |
+          echo "DATABRICKS_HOST=${{ env.DATABRICKS_HOST }}" >> $GITHUB_ENV
+          echo "GOOGLE_CREDENTIALS=${{ steps.google_auth.outputs.credentials_file_path }}" >> $GITHUB_ENV
+      - uses: databricks/setup-cli@main
+        name: Setup databricks CLI
+      - name: Set Databricks env variables
+        run: |
+          echo "CREDENTIAL_ID=''" >> $GITHUB_ENV
+      - name: Create git-credentials
+        run: |
+          OUTPUT=$(databricks git-credentials create gitHub --git-username $GITHUB_ACTOR --personal-access-token ${{ secrets.GITHUB_TOKEN }})
+          echo "$OUTPUT"
+          CREDENTIAL_ID=$(echo "$OUTPUT" | jq -r '.credential_id')
+          echo "CREDENTIAL_ID=$CREDENTIAL_ID" >> $GITHUB_ENV
+      - name: Check if Databricks repo exists
+        run: |
+          set +e 
+          REPO_EXISTS=$(databricks workspace list $DATABRICKS_REPO_FOLDER --output json | \
+            jq -r --arg REPO_PATH "$DATABRICKS_REPO_PATH" \
+            'if . != null then (map(select(.path == $REPO_PATH)) | if length > 0 then "true" else "false" end) else "false" end')
+          echo "REPO_EXISTS=$REPO_EXISTS" >> $GITHUB_ENV
+          set -e
+      - name: Create Databricks Repo if it does not exist
+        if: env.REPO_EXISTS == 'false'
+        run: |
+          databricks repos create ${{ env.REPO_URL }} gitHub --path ${{ env.DATABRICKS_REPO_PATH }}
+      - name: Update Databricks Repo if it exists
+        if: env.REPO_EXISTS == 'true'
+        run: |
+          databricks repos update ${{ env.DATABRICKS_REPO_PATH }} --branch "${{ env.DATABRICKS_DEPLOY_BRANCH }}"
+      - name: Delete git-credentials
+        if: always() && env.CREDENTIAL_ID != ''
+        run: |
+          databricks git-credentials delete $CREDENTIAL_ID

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,118 +1,118 @@
 name: Build and publish Docker Image
 
 on:
-    workflow_call:
-        inputs:
-            context_path:
-                required: true
-                type: string
-            version_file_name:
-                required: true
-                type: string
-            apps_repo:
-                required: true
-                type: string
-            version_file_directory:
-                description: "Directory where version file with image ref is stored"
-                required: false
-                default: "./versions"
-                type: string
-            identity:
-                required: true
-                type: string
-        outputs:
-            image_url:
-                value: ${{ jobs.build.outputs.image_url }}
+  workflow_call:
+    inputs:
+      context_path:
+        required: true
+        type: string
+      version_file_name:
+        required: true
+        type: string
+      apps_repo:
+        required: true
+        type: string
+      version_file_directory:
+        description: "Directory where version file with image ref is stored"
+        required: false
+        default: "./versions"
+        type: string
+      identity:
+        required: true
+        type: string
+    outputs:
+      image_url:
+        value: ${{ jobs.build.outputs.image_url }}
 
 env:
-    REGISTRY: ghcr.io
-    CONTEXT_PATH: ${{ inputs.context_path }}
-    APPS_REPO: ${{ inputs.apps_repo }}
-    BRANCH: ${{ github.head_ref || github.ref_name }}
-    IDENTITY: ${{ inputs.identity }}
+  REGISTRY: ghcr.io
+  CONTEXT_PATH: ${{ inputs.context_path }}
+  APPS_REPO: ${{ inputs.apps_repo }}
+  BRANCH: ${{ github.head_ref || github.ref_name }}
+  IDENTITY: ${{ inputs.identity }}
 
 jobs:
-    build:
-        name: Build container image
-        runs-on: ubuntu-latest
-        outputs:
-            image_url: ${{ steps.set_output.outputs.image_url }}
-        steps:
-            - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
-              id: octo-sts
-              with:
-                  scope: kartverket/dask-apps
-                  identity: ${{ env.IDENTITY }}
+  build:
+    name: Build container image
+    runs-on: ubuntu-latest
+    outputs:
+      image_url: ${{ steps.set_output.outputs.image_url }}
+    steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
+        id: octo-sts
+        with:
+          scope: kartverket/dask-apps
+          identity: ${{ env.IDENTITY }}
 
-            - name: Checkout repository
-              uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-            - name: Check for changes in context path
-              id: check_changes
-              run: |
-                  if git diff --quiet HEAD^ HEAD -- ${{ env.CONTEXT_PATH }}; then
-                    echo "No changes in ${{ env.CONTEXT_PATH }}. Skipping build."
-                    echo "::set-output name=skip_build::true"
-                  else
-                    echo "::set-output name=skip_build::false"
-                  fi
+      - name: Check for changes in context path
+        id: check_changes
+        run: |
+          if git diff --quiet HEAD^ HEAD -- ${{ env.CONTEXT_PATH }}; then
+            echo "No changes in ${{ env.CONTEXT_PATH }}. Skipping build."
+            echo "::set-output name=skip_build::true"
+          else
+            echo "::set-output name=skip_build::false"
+          fi
 
-            - name: Login to Github Container Registry
-              if: steps.check_changes.outputs.skip_build == 'false'
-              uses: docker/login-action@v2
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ github.token }}
+      - name: Login to Github Container Registry
+        if: steps.check_changes.outputs.skip_build == 'false'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
-            - name: Build and push Docker image
-              if: steps.check_changes.outputs.skip_build == 'false'
-              id: build-docker
-              uses: docker/build-push-action@v5
-              with:
-                  file: ${{ env.CONTEXT_PATH }}/Dockerfile
-                  context: ${{ env.CONTEXT_PATH }}
-                  push: ${{ !github.event.pull_request.draft }}
-                  tags: ${{ env.REGISTRY }}/${{ github.repository }}:latest
+      - name: Build and push Docker image
+        if: steps.check_changes.outputs.skip_build == 'false'
+        id: build-docker
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ env.CONTEXT_PATH }}/Dockerfile
+          context: ${{ env.CONTEXT_PATH }}
+          push: ${{ !github.event.pull_request.draft }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:latest
 
-            - name: Checkout the repository
-              if: steps.check_changes.outputs.skip_build == 'false'
-              uses: actions/checkout@v3
-              with:
-                  repository: kartverket/${{ env.APPS_REPO }}
-                  ref: main
-                  token: ${{ steps.octo-sts.outputs.token }}
+      - name: Checkout the repository
+        if: steps.check_changes.outputs.skip_build == 'false'
+        uses: actions/checkout@v3
+        with:
+          repository: kartverket/${{ env.APPS_REPO }}
+          ref: main
+          token: ${{ steps.octo-sts.outputs.token }}
 
-            - name: Create file
-              if: steps.check_changes.outputs.skip_build == 'false'
-              run: |
-                  setup_directory () {
-                      DIRECTORY=${{ inputs.version_file_directory }}
-                      touch $DIRECTORY/${{ inputs.version_file_name }}
-                      echo "\"${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}\"" > $DIRECTORY/${{ inputs.version_file_name }} 
-                  }
+      - name: Create file
+        if: steps.check_changes.outputs.skip_build == 'false'
+        run: |
+          setup_directory () {
+              DIRECTORY=${{ inputs.version_file_directory }}
+              touch $DIRECTORY/${{ inputs.version_file_name }}
+              echo "\"${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}\"" > $DIRECTORY/${{ inputs.version_file_name }} 
+          }
 
-                  if [[ "${{ env.BRANCH }}" == "main" ]]; then
-                      setup_directory 
-                  fi
+          if [[ "${{ env.BRANCH }}" == "main" ]]; then
+              setup_directory 
+          fi
 
-            - name: Commit and Push Changes
-              if: steps.check_changes.outputs.skip_build == 'false'
-              run: |
-                  git config --global user.email "noreply@kartverket.no"
-                  git config --global user.name "DASK CI"
-                  git add .
-                  if git diff --staged --quiet; then
-                    echo "No changes to commit."
-                  else
-                    git commit -m "Update ${{ inputs.version_file_name }}"
-                    git push
-                  fi
+      - name: Commit and Push Changes
+        if: steps.check_changes.outputs.skip_build == 'false'
+        run: |
+          git config --global user.email "noreply@kartverket.no"
+          git config --global user.name "DASK CI"
+          git add .
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "Update ${{ inputs.version_file_name }}"
+            git push
+          fi
 
-            - name: Set output with build values
-              if: steps.check_changes.outputs.skip_build == 'false'
-              id: set_output
-              run: |
-                  echo "image_url=${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}" >> $GITHUB_OUTPUT
+      - name: Set output with build values
+        if: steps.check_changes.outputs.skip_build == 'false'
+        id: set_output
+        run: |
+          echo "image_url=${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-message-pubsub.yml
+++ b/.github/workflows/publish-message-pubsub.yml
@@ -1,65 +1,63 @@
-name: Create empty GitHub repo and clone monorepo into it
+name: Publish message to PubSub onboarding topic
 
 on:
-  workflow_call:
-    inputs:
-      service_account:
-        description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
-        required: true
-        type: string
-      auth_project_number:
-        description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
-        required: true
-        type: string
-      team_name:
-        description: "The unique name representing the team that is undergoing the onboarding process to DASK."
-        required: true
-        type: string
-      step_id:
-        description: "The step id to notify completion for to the pub sub onboarding topic."
-        required: true
-        type: string
-      params:
-        description: "The params appended to by each step of the onboarding flow."
-        required: false
-        type: string
-        default: "null"
+    workflow_call:
+        inputs:
+            service_account:
+                description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
+                required: true
+                type: string
+            auth_project_number:
+                description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
+                required: true
+                type: string
+            team_name:
+                description: "The unique name representing the team that is undergoing the onboarding process to DASK."
+                required: true
+                type: string
+            step_id:
+                description: "The step id to notify completion for to the pub sub onboarding topic."
+                required: true
+                type: string
+            params:
+                description: "The params appended to by each step of the onboarding flow."
+                required: false
+                type: string
+                default: "null"
 
 env:
-  AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
-  SERVICE_ACCOUNT: ${{ inputs.service_account }}
-  TEAM_NAME: ${{ inputs.team_name }}
-  STEP_ID: ${{ inputs.step_id }}
-  PARAMS: ${{ inputs.params }}
-  PUBSUB_TOPIC: onboarding_topic
-
+    AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
+    SERVICE_ACCOUNT: ${{ inputs.service_account }}
+    TEAM_NAME: ${{ inputs.team_name }}
+    STEP_ID: ${{ inputs.step_id }}
+    PARAMS: ${{ inputs.params }}
+    PUBSUB_TOPIC: onboarding_topic
 
 jobs:
-  publish_message_to_pubsub_onboarding_topic:
-    name: Notify task completion to the onboarding PubSub-topic
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set vars
-        id: set-output
-        run: |
-          PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
-          DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
-          OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
-          PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
-          echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
+    publish_message_to_pubsub_onboarding_topic:
+        name: Notify task completion to the onboarding PubSub-topic
+        runs-on: ubuntu-latest
+        steps:
+            - name: Set vars
+              id: set-output
+              run: |
+                  PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
+                  DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
+                  OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
+                  PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
+                  echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
 
-      - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@v1
-        with:
-          workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.SERVICE_ACCOUNT }}
-      
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
-        with:
-          version: '>= 363.0.0'
+            - name: Authenticate with Google Cloud
+              uses: google-github-actions/auth@v1
+              with:
+                  workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+                  service_account: ${{ env.SERVICE_ACCOUNT }}
 
-      - name: Add message to PubSub topic
-        run: |
-          gcloud pubsub topics publish ${{ env.PUBSUB_TOPIC }} --message='{ "team_name": "${{ env.TEAM_NAME }}", "step": "${{ env.STEP_ID }}", "params": ${{ env.PARAMS }} }'
+            - name: "Set up Cloud SDK"
+              uses: "google-github-actions/setup-gcloud@v2"
+              with:
+                  version: ">= 363.0.0"
 
+            - name: Add message to PubSub topic
+              run: |
+                  gcloud pubsub topics publish ${{ env.PUBSUB_TOPIC }} --message='{ "team_name": "${{ env.TEAM_NAME }}", "step": "${{ env.STEP_ID }}", "params": ${{ env.PARAMS }} }'

--- a/.github/workflows/publish-message-pubsub.yml
+++ b/.github/workflows/publish-message-pubsub.yml
@@ -1,63 +1,63 @@
 name: Publish message to PubSub onboarding topic
 
 on:
-    workflow_call:
-        inputs:
-            service_account:
-                description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
-                required: true
-                type: string
-            auth_project_number:
-                description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
-                required: true
-                type: string
-            team_name:
-                description: "The unique name representing the team that is undergoing the onboarding process to DASK."
-                required: true
-                type: string
-            step_id:
-                description: "The step id to notify completion for to the pub sub onboarding topic."
-                required: true
-                type: string
-            params:
-                description: "The params appended to by each step of the onboarding flow."
-                required: false
-                type: string
-                default: "null"
+  workflow_call:
+    inputs:
+      service_account:
+        description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
+        required: true
+        type: string
+      auth_project_number:
+        description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
+        required: true
+        type: string
+      team_name:
+        description: "The unique name representing the team that is undergoing the onboarding process to DASK."
+        required: true
+        type: string
+      step_id:
+        description: "The step id to notify completion for to the pub sub onboarding topic."
+        required: true
+        type: string
+      params:
+        description: "The params appended to by each step of the onboarding flow."
+        required: false
+        type: string
+        default: "null"
 
 env:
-    AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
-    SERVICE_ACCOUNT: ${{ inputs.service_account }}
-    TEAM_NAME: ${{ inputs.team_name }}
-    STEP_ID: ${{ inputs.step_id }}
-    PARAMS: ${{ inputs.params }}
-    PUBSUB_TOPIC: onboarding_topic
+  AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
+  SERVICE_ACCOUNT: ${{ inputs.service_account }}
+  TEAM_NAME: ${{ inputs.team_name }}
+  STEP_ID: ${{ inputs.step_id }}
+  PARAMS: ${{ inputs.params }}
+  PUBSUB_TOPIC: onboarding_topic
 
 jobs:
-    publish_message_to_pubsub_onboarding_topic:
-        name: Notify task completion to the onboarding PubSub-topic
-        runs-on: ubuntu-latest
-        steps:
-            - name: Set vars
-              id: set-output
-              run: |
-                  PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
-                  DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
-                  OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
-                  PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
-                  echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
+  publish_message_to_pubsub_onboarding_topic:
+    name: Notify task completion to the onboarding PubSub-topic
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set vars
+        id: set-output
+        run: |
+          PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
+          DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
+          OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
+          PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
+          echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
 
-            - name: Authenticate with Google Cloud
-              uses: google-github-actions/auth@v1
-              with:
-                  workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
-                  service_account: ${{ env.SERVICE_ACCOUNT }}
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
 
-            - name: "Set up Cloud SDK"
-              uses: "google-github-actions/setup-gcloud@v2"
-              with:
-                  version: ">= 363.0.0"
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v2"
+        with:
+          version: ">= 363.0.0"
 
-            - name: Add message to PubSub topic
-              run: |
-                  gcloud pubsub topics publish ${{ env.PUBSUB_TOPIC }} --message='{ "team_name": "${{ env.TEAM_NAME }}", "step": "${{ env.STEP_ID }}", "params": ${{ env.PARAMS }} }'
+      - name: Add message to PubSub topic
+        run: |
+          gcloud pubsub topics publish ${{ env.PUBSUB_TOPIC }} --message='{ "team_name": "${{ env.TEAM_NAME }}", "step": "${{ env.STEP_ID }}", "params": ${{ env.PARAMS }} }'

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -71,7 +71,6 @@ env:
   TF_INIT_OPTION_3: ${{ inputs.terraform_init_option_3 }}
   TF_OPTION_1: ${{ inputs.terraform_option_1 }}
 
-
 jobs:
   setup-env:
     runs-on: ubuntu-latest
@@ -87,7 +86,7 @@ jobs:
           PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
           echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
   deploy_databricks:
-    needs: [ setup-env ]
+    needs: [setup-env]
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.environment }}


### PR DESCRIPTION
Vi bruker fortsatt min PAT når vi lager nytt repo og oppretter PR-er. Vi bør jobbe med personuavhengige tokens, så erstatter PAT med octo-sts. 

Denne endringen fører til at vi må gjøre en rekke endringer i andre repoer:
- Legge inn filen `.github/chainguard/dask-modules.sts.yaml` i alle repoer vi skriver til (skip-core-infrastructure, gcp-service-accounts, dask-infrastructure)
- Oppdatere monorepoet med det samme slik at alle nye repoer tillater skriving fra dask-modules
- Oppdatere payload i [onboarding-service](https://github.com/kartverket/dask-onboarding-service/blob/main/github_utils.py#L139) med identity-inputparameteren