### PR TITLE
Fjern default-verdi for issuer_uri

### DIFF
--- a/.github/workflows/create-and-clone-repo.yml
+++ b/.github/workflows/create-and-clone-repo.yml
@@ -57,6 +57,7 @@ jobs:
                 }
             });
             console.log(`Response for creating repo ${repoName}:`, response);
+
       - name: Set DASK group as admin
         if: env.DEBUG_MODE == 'false'
         uses: actions/github-script@v7

--- a/terraform/modules/skyporten_workload_identity/main.tf
+++ b/terraform/modules/skyporten_workload_identity/main.tf
@@ -16,7 +16,7 @@ resource "google_iam_workload_identity_pool_provider" "maskinporten" {
   description  = "OIDC identity pool provider for Maskinporten"
   oidc {
     allowed_audiences = [var.required_audience]
-    issuer_uri        = var.issuer_uri
+    issuer_uri        = var.skyporten_env == "test" ? "https://test.sky.maskinporten.no" : "https://sky.maskinporten.no"
   }
 }
 

--- a/terraform/modules/skyporten_workload_identity/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/variables.tf
@@ -41,8 +41,10 @@ variable "sub_scope" {
 
 variable "skyporten_env" {
   description = "The environment to deploy the Skyporten integration in"
+  type        = string
+
   validation {
-    condition     = can(regex("^(test|prod)$", var.skyporten_env))
-    error_message = "The skyporten_env variable must be either test or prod"
+    condition     = contains(["test", "prod"], var.skyporten_env)
+    error_message = "The skyporten_env variable must be either 'test' or 'prod'."
   }
 }

--- a/terraform/modules/skyporten_workload_identity/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/variables.tf
@@ -33,7 +33,6 @@ variable "project_id" {
 
 variable "issuer_uri" {
   description = "The issuer URI for the OICD identity pool provider"
-  default     = "https://test.sky.maskinporten.no"
 }
 
 variable "main_scope" {

--- a/terraform/modules/skyporten_workload_identity/variables.tf
+++ b/terraform/modules/skyporten_workload_identity/variables.tf
@@ -30,11 +30,6 @@ variable "project_id" {
   description = "The project ID of the project"
 }
 
-
-variable "issuer_uri" {
-  description = "The issuer URI for the OICD identity pool provider"
-}
-
 variable "main_scope" {
   description = "The main organisation scope for the Maskinporten client."
   default     = "kartverk"
@@ -42,4 +37,12 @@ variable "main_scope" {
 
 variable "sub_scope" {
   description = "The sub scope for the Maskinporten client."
+}
+
+variable "skyporten_env" {
+  description = "The environment to deploy the Skyporten integration in"
+  validation {
+    condition     = can(regex("^(test|prod)$", var.skyporten_env))
+    error_message = "The skyporten_env variable must be either test or prod"
+  }
 }


### PR DESCRIPTION
`issuer_uri` er default satt til Maskinporten i test. Dette kan ha uheldige konsekvenser, da brukeren av modulen kan tro de er beskyttet av pålogging i produksjon. Hvis de ikke har satt verdien, som flere sannsynligvis ikke har gjort siden den ikke er påkrevd, vil de bruke test-pålogging som er en mye mindre beskyttet. 

Det er en kritisk feil som kan føre til at man tillater deling av produksjonsdata med test-pålogging. Derfor fjerner vi `issuer_uri`-variabelen og legger heller på `skyporten_env` der modulen bestemmer uri-en ut fra variabelen. Kun test og prod vil være gyldige verdier 