### PR TITLE
Bytte til å bruke id for kodelistene

### DIFF
--- a/dask-felleskomponenter/example_table_metadata_gold.json
+++ b/dask-felleskomponenter/example_table_metadata_gold.json
@@ -4,13 +4,13 @@
     "table": "table",
     "tittel": "tittel",
     "beskrivelse": "beskrivelse",
-    "tilgangsnivaa": "Allmen tilgang",
+    "tilgangsnivaa": "http://publications.europa.eu/resource/authority/access-right/PUBLIC",
     "medaljongnivaa": "gold",
-    "hovedkategori": "Basisdata",
-    "begrep": "Landskap",
+    "hovedkategori": "https://register.geonorge.no/metadata-kodelister/tematisk-hovedkategori/farming",
+    "begrep": "https://register.geonorge.no/metadata-kodelister/nasjonal-temainndeling/Samfunnssikkerhet",
     "epsg_koder": "25835",
     "emneord": "bruksomraade",
-    "sikkerhetsnivaa": "Ugradert",
+    "sikkerhetsnivaa": "https://register.geonorge.no/metadata-kodelister/sikkerhetsnivaa/unclassified_sensitive",
     "column_properties": {
         "geometri": {
             "epsg": "25835",

--- a/dask-felleskomponenter/setup.py
+++ b/dask-felleskomponenter/setup.py
@@ -7,7 +7,7 @@ packages = setuptools.find_packages(where="src")
 
 setuptools.setup(
     name="dask-felleskomponenter",
-    version="0.0.33",
+    version="0.1.0",
     author="Dataplattform@Statens Kartverk",
     author_email="dataplattform@kartverket.no",
     description="Felleskomponenter på DASK",

--- a/dask-felleskomponenter/setup.py
+++ b/dask-felleskomponenter/setup.py
@@ -7,7 +7,7 @@ packages = setuptools.find_packages(where="src")
 
 setuptools.setup(
     name="dask-felleskomponenter",
-    version="0.1.2",
+    version="0.1.3",
     author="Dataplattform@Statens Kartverk",
     author_email="dataplattform@kartverket.no",
     description="Felleskomponenter på DASK",

--- a/dask-felleskomponenter/setup.py
+++ b/dask-felleskomponenter/setup.py
@@ -7,7 +7,7 @@ packages = setuptools.find_packages(where="src")
 
 setuptools.setup(
     name="dask-felleskomponenter",
-    version="0.1.1",
+    version="0.1.2",
     author="Dataplattform@Statens Kartverk",
     author_email="dataplattform@kartverket.no",
     description="Felleskomponenter på DASK",

--- a/dask-felleskomponenter/setup.py
+++ b/dask-felleskomponenter/setup.py
@@ -7,7 +7,7 @@ packages = setuptools.find_packages(where="src")
 
 setuptools.setup(
     name="dask-felleskomponenter",
-    version="0.1.0",
+    version="0.1.1",
     author="Dataplattform@Statens Kartverk",
     author_email="dataplattform@kartverket.no",
     description="Felleskomponenter på DASK",

--- a/dask-felleskomponenter/setup.py
+++ b/dask-felleskomponenter/setup.py
@@ -7,7 +7,7 @@ packages = setuptools.find_packages(where="src")
 
 setuptools.setup(
     name="dask-felleskomponenter",
-    version="0.0.32",
+    version="0.0.33",
     author="Dataplattform@Statens Kartverk",
     author_email="dataplattform@kartverket.no",
     description="Felleskomponenter på DASK",

--- a/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/column.py
+++ b/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/column.py
@@ -16,7 +16,9 @@ def check_geometri_encoding(metadata: TableMetadata, context: List) -> List[Meta
             error_obj = MetadataError(catalog=metadata.catalog, 
                                         schema=metadata.schema, 
                                         table=metadata.table, 
-                                        column=key, 
+                                        column=key,
+                                        for_field="geometri_encoding",
+                                        valid_values=valid_geometri_encoding,
                                         description="🔴 Feil: 'geometri_encoding' mangler i column properties. Type: <geometri_encoding> - gyldige verdier er WKT, WKB, GeoJson eller S2cell ", 
                                         solution=f"ALTER TABLE {metadata.catalog}.{metadata.schema}.{metadata.table} SET TBLPROPERTIES ( 'columns.{key}.geometri_encoding' = '<<SETT_ROMLIG_REPRESENTASJONSTYPE_HER>>')")
             context.append(error_obj)

--- a/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/column.py
+++ b/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/column.py
@@ -5,6 +5,9 @@ from .geometri_encoding_kodeliste import geometri_encoding_kodeliste
 valid_geometri_encoding = [val["codevalue"].lower() for val in geometri_encoding_kodeliste["containeditems"]]
 
 def check_geometri_encoding(metadata: TableMetadata, context: List) -> List[MetadataError]:
+    if metadata.column_properties is None:
+        return
+
     for key, val in metadata.column_properties.items():
         epsg = val.get("epsg", None)
         geometry_encoding = val.get("geometri_encoding", "")

--- a/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/column.py
+++ b/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/column.py
@@ -6,14 +6,17 @@ valid_geometri_encoding = [val["codevalue"].lower() for val in geometri_encoding
 
 def check_geometri_encoding(metadata: TableMetadata, context: List) -> List[MetadataError]:
     for key, val in metadata.column_properties.items():
-        if val["epsg"] is None:
+        epsg = val.get("epsg", None)
+        geometry_encoding = val.get("geometri_encoding", "")
+        
+        if epsg is None:
             continue
         
-        if val["geometri_encoding"].lower() not in valid_geometri_encoding:
+        if geometry_encoding.lower() not in valid_geometri_encoding:
             error_obj = MetadataError(catalog=metadata.catalog, 
                                         schema=metadata.schema, 
                                         table=metadata.table, 
-                                        column=None, 
+                                        column=key, 
                                         description="🔴 Feil: 'geometri_encoding' mangler i column properties. Type: <geometri_encoding> - gyldige verdier er WKT, WKB, GeoJson eller S2cell ", 
                                         solution=f"ALTER TABLE {metadata.catalog}.{metadata.schema}.{metadata.table} SET TBLPROPERTIES ( 'columns.{key}.geometri_encoding' = '<<SETT_ROMLIG_REPRESENTASJONSTYPE_HER>>')")
             context.append(error_obj)

--- a/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/common.py
+++ b/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/common.py
@@ -1,10 +1,15 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
-import os
-import json
+from .sikkerhetsnivaa_kodeliste import sikkerhetsnivaa_kodeliste
+from .tilgangsnivaa_kodeliste import tilgangsnivaa_kodeliste
 
 import requests
 
+medaljongnivaa_kodeliste = ["bronze", "silver", "gold"]
+
+class CodelistUrls:
+    hovedkategori = "https://register.geonorge.no/metadata-kodelister/tematisk-hovedkategori"
+    begrep = "https://register.geonorge.no/metadata-kodelister/nasjonal-temainndeling"
 
 @dataclass(init=False)
 class TableMetadata:
@@ -45,13 +50,13 @@ class MetadataError:
     valid_values: str | List[str]
 
 def get_valid_codelist_values(kodeliste_url: str, override_kodeliste_keyword: Optional[str] = None) -> List[str]:
-    kodeliste_entry = "label" if override_kodeliste_keyword == None else override_kodeliste_keyword
+    kodeliste_entry = "id" if override_kodeliste_keyword == None else override_kodeliste_keyword
     values_res = requests.get(kodeliste_url, headers={ "Accept": "application/json" }).json()
     valid_values = list(filter(lambda x: x != None, [x.get(kodeliste_entry, None) for x in values_res["containeditems"]]))
     return valid_values
 
 def get_valid_codelist_values_local(kodeliste: dict, override_kodeliste_keyword: Optional[str] = None) -> List[str]:
-    kodeliste_entry = "label" if override_kodeliste_keyword is None else override_kodeliste_keyword
+    kodeliste_entry = "id" if override_kodeliste_keyword is None else override_kodeliste_keyword
     
     valid_values = list(filter(lambda x: x is not None, 
                              [x.get(kodeliste_entry, None) for x in kodeliste["containeditems"]]))
@@ -86,6 +91,20 @@ def check_codelist_value_local(kodeliste_path: str, value: Any, allowed_values: 
 
     valid_values = get_valid_codelist_values_local(kodeliste_path, override_kodeliste_keyword)
     return value in valid_values
+
+def get_codelist(key: str) -> List[str]:
+    if key == "hovedkategori":
+        return get_valid_codelist_values(CodelistUrls.hovedkategori)
+    elif key == "begrep":
+        return get_valid_codelist_values(CodelistUrls.begrep)
+    elif key == "tilgangsnivaa":
+        return get_valid_codelist_values_local(tilgangsnivaa_kodeliste)
+    elif key == "medaljongnivaa":
+        return medaljongnivaa_kodeliste
+    elif key == "sikkerhetsnivaa":
+        return get_valid_codelist_values_local(sikkerhetsnivaa_kodeliste)
+    
+    return None
 
 if __name__ == "__main__":
     # Example usage of both local and remote codelist checking

--- a/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/common.py
+++ b/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/common.py
@@ -59,7 +59,7 @@ class MetadataError:
     description: str
     solution: Optional[str]
     for_field: str
-    valid_values: str | List[str]
+    valid_values: str | List[CodelistEntry]
 
 def get_valid_codelist_values(kodeliste_url: str, override_kodeliste_keyword: Optional[str] = None, override_kodeliste_label_keyword: Optional[str] = None) -> List[CodelistEntry]:
     kodeliste_entry = "id" if override_kodeliste_keyword == None else override_kodeliste_keyword

--- a/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/table.py
+++ b/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/table.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from .common import MetadataError, check_codelist_value, TableMetadata, get_valid_codelist_values, check_codelist_value_local, get_valid_codelist_values_local
+from .common import MetadataError, check_codelist_value, TableMetadata, get_valid_codelist_values, check_codelist_value_local, get_valid_codelist_values_local, CodelistUrls, medaljongnivaa_kodeliste
 from .sikkerhetsnivaa_kodeliste import sikkerhetsnivaa_kodeliste
 from .tilgangsnivaa_kodeliste import tilgangsnivaa_kodeliste
 from .column import check_geometri_encoding
@@ -35,14 +35,14 @@ def check_tilgangsnivaa(metadata: TableMetadata, context: List[MetadataError]) -
     return context
 
 def check_medaljongnivaa(metadata: TableMetadata, context: List[MetadataError]) -> List[MetadataError]:
-    valid_values = ["bronze", "silver", "gold"]
+    valid_values = medaljongnivaa_kodeliste
     if not check_codelist_value(None, metadata.medaljongnivaa, valid_values):
         context.append(_generate_metadata_error(metadata.catalog, metadata.schema, metadata.table, "medaljongnivaa", "valør", metadata.medaljongnivaa == None, f"gyldige verdier: {valid_values}", valid_values=valid_values))
     
     return context
 
 def check_hovedkategori(metadata: TableMetadata, context: List[MetadataError]) -> List[MetadataError]:
-    kodeliste_url = "https://register.geonorge.no/metadata-kodelister/tematisk-hovedkategori"
+    kodeliste_url = CodelistUrls.hovedkategori
 
     if not check_codelist_value(kodeliste_url, metadata.hovedkategori):
         valid_values = get_valid_codelist_values(kodeliste_url)
@@ -64,7 +64,7 @@ def check_sikkerhetsnivaa(metadata: TableMetadata, context: List[MetadataError])
     return context
 
 def check_begrep(metadata: TableMetadata, context: List[MetadataError]) -> List[MetadataError]:
-    kodeliste_url = "https://register.geonorge.no/metadata-kodelister/nasjonal-temainndeling"
+    kodeliste_url = CodelistUrls.begrep
 
     if not check_codelist_value(kodeliste_url, metadata.begrep):
         valid_values = get_valid_codelist_values(kodeliste_url)

--- a/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/table.py
+++ b/dask-felleskomponenter/src/dask_felleskomponenter/governance/checks/table.py
@@ -74,7 +74,7 @@ def check_begrep(metadata: TableMetadata, context: List[MetadataError]) -> List[
     
 checks_for_valor = {
     "bronze": [check_tittel, check_beskrivelse, check_sikkerhetsnivaa],
-    "silver":   [check_tittel, check_beskrivelse, check_emneord, check_begrep, check_sikkerhetsnivaa],
+    "silver": [check_tittel, check_beskrivelse, check_emneord, check_begrep, check_sikkerhetsnivaa],
     "gold":   [check_tittel, check_beskrivelse, check_hovedkategori, check_emneord, check_begrep, check_tilgangsnivaa, check_sikkerhetsnivaa, check_geometri_encoding],
 }
 


### PR DESCRIPTION
Denne endringen medfører at vi må bruke den nye funksjonen `get_codelist(key: str)`, for å kunne beholde visningen på korrekt måte som idag.