### PR TITLE
Sett opp chainguard for SKIP repos

### DIFF
--- a/.github/chainguard/gcp-service-accounts.sts.yaml
+++ b/.github/chainguard/gcp-service-accounts.sts.yaml
@@ -1,0 +1,5 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: '^repo:kartverket\/gcp-service-accounts:ref:refs\/main\/.+$'
+
+permissions:
+  contents: read

--- a/.github/chainguard/gcp-service-accounts.sts.yaml
+++ b/.github/chainguard/gcp-service-accounts.sts.yaml
@@ -3,3 +3,5 @@ subject_pattern: '^repo:kartverket\/gcp-service-accounts:ref:refs\/main\/.+$'
 
 permissions:
   contents: read
+  actions: write
+  workflows: write

--- a/.github/chainguard/skip-core-infrastructure.sts.yaml
+++ b/.github/chainguard/skip-core-infrastructure.sts.yaml
@@ -3,3 +3,5 @@ subject_pattern: '^repo:kartverket\/skip-core-infrastructure:ref:refs\/main\/.+$
 
 permissions:
   contents: read
+  actions: write
+  workflows: write

--- a/.github/chainguard/skip-core-infrastructure.sts.yaml
+++ b/.github/chainguard/skip-core-infrastructure.sts.yaml
@@ -1,0 +1,5 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: '^repo:kartverket\/skip-core-infrastructure:ref:refs\/main\/.+$'
+
+permissions:
+  contents: read


### PR DESCRIPTION
Vi ønsker å trigge en action fra gcp-service-accounts og skip-core-infrastructure når det skjer endringer på infrastruktur, for å hente ut team-id-er++ for automatisering av oppsett av nye team og pushe dette inn på en kø som leses av dask-onboarding-service.