### PR TITLE
TD-1400 setup workflow for gcp teams fetch and publish

### DIFF
--- a/.github/workflows/fetch-and-publish-gcp-teams-data.yml
+++ b/.github/workflows/fetch-and-publish-gcp-teams-data.yml
@@ -1,0 +1,17 @@
+name: Fetch and Publish Product Team Data From GCP
+
+on:
+  workflow_call:
+    inputs:
+      token:
+        description: "GCP token"
+        required: true
+        type: string
+
+jobs:
+  fetch-teams-from-gcp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heisann
+        id: heisann
+        run: echo "heisann!"

--- a/.github/workflows/fetch-and-publish-gcp-teams-data.yml
+++ b/.github/workflows/fetch-and-publish-gcp-teams-data.yml
@@ -1,17 +1,57 @@
 name: Fetch and Publish Product Team Data From GCP
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
-      token:
-        description: "GCP token"
+      auth_project_number:
+        description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
         required: true
         type: string
+      project_id:
+        description: 'The GCP Project ID to use as the "active project" when running Terraform. Example 123456789987'
+        required: false
+        type: string
+      service_account:
+        description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
+        required: true
+        type: string
+      workload_identity_provider_override:
+        description: "The ID of the provider to use for authentication. Only used for overriding the default workload identity provider based on project number. It should be in the format of `projects/{{project}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/providers/{{workload_identity_pool_provider_id}}`"
+        required: false
+        type: string
+
+env:
+  AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
+  PROJECT_ID: ${{ inputs.project_id }}
+  SERVICE_ACCOUNT: ${{ inputs.service_account }}
+  WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
 
 jobs:
+  setup-env:
+    runs-on: ubuntu-latest
+    outputs:
+      workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+    steps:
+      - name: Set vars
+        id: set-output
+        run: |
+          PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
+          DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
+          OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
+          PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
+          
+          echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
+
   fetch-teams-from-gcp:
     runs-on: ubuntu-latest
     steps:
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+          project_id: ${{ env.PROJECT_ID }}
+
       - name: Heisann
         id: heisann
         run: echo "heisann!"


### PR DESCRIPTION
Setter opp en dummy-workflow som testes med workflow_dispatch inntil den fungerer og kan trigges fra gcp-service-accoutns og skip-core-infrastructure (ved terraformendringer).