### PR TITLE
Permission for entra-id-config

### DIFF
--- a/.github/chainguard/entra-id-config.yaml
+++ b/.github/chainguard/entra-id-config.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:kartverket/entra-id-config:ref:refs/heads/main
+
+permissions:
+  contents: read
+  actions: write
+  workflows: write


### PR DESCRIPTION
Vi ønsker å bli varslet ved endringer av org-struktur, slik at vi kan lagre "short names" for de ulike teamene.