### PR TITLE
Legg til pharos for scanning av IaC

### DIFF
--- a/.github/workflows/pull-request-actions.yml
+++ b/.github/workflows/pull-request-actions.yml
@@ -1,0 +1,20 @@
+name: Pull Request Actions
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  pharos-scan:
+    name: Run Pharos with Required Permissions
+    permissions:
+      actions: read
+      packages: read
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Run Pharos"
+        uses: kartverket/pharos@v0.3.3
+        with:
+          allow_severity_level: high


### PR DESCRIPTION
### Beskrivelse

Legger til pharos for scanning av IaC-kode, slik at vi får sikkerhetsfeedback på samme punkt som produktteamene som bruker modulene våre.

Se resultat fra kodescanning her: https://github.com/kartverket/dask-modules/security/code-scanning?query=pr%3A161+is%3Aopen