### PR TITLE
Kjør pharos på push til main

### DIFF
--- a/.github/workflows/pull-request-actions.yml
+++ b/.github/workflows/pull-request-actions.yml
@@ -3,6 +3,8 @@ name: Pull Request Actions
 on:
   pull_request:
     types: [opened, synchronize]
+  push:
+    branches: [main]
 
 jobs:
   pharos-scan:


### PR DESCRIPTION
For at ikke resultatene av scan bare skal bli liggende på branchen som PR tok utgangspunkt i, men at man faktisk får opp resultatet i `Security`-tabben i repoet, må scan også kjøres når man pusher til main (tror jeg 🤞 )