### PR TITLE
Unpin provider versions

### DIFF
--- a/terraform/modules/cloud_function_v2/backend.tf
+++ b/terraform/modules/cloud_function_v2/backend.tf
@@ -2,11 +2,9 @@ terraform {
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.7.0"
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.14.0"
     }
   }
 }

--- a/terraform/modules/databricks_pubsub/backend.tf
+++ b/terraform/modules/databricks_pubsub/backend.tf
@@ -7,7 +7,6 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.14.0"
     }
 
   }


### PR DESCRIPTION
Disse versjonslåsene låser providerne i alle prosjekter som bruker disse modulene. Regner med at det bare bør brukes hvis det er helt nødvendig.