### PR TITLE
Create a repository_dispatch test workflow

### DIFF
--- a/.github/workflows/test-repo-dispatch.yml
+++ b/.github/workflows/test-repo-dispatch.yml
@@ -3,6 +3,7 @@ name: Create onboarding pull request for new product
 on:
   repository_dispatch:
     types: [onboarding]
+  workflow_dispatch:
 
 jobs:
   run-test:


### PR DESCRIPTION
Vi sliter med å få repository_dispatch til å funke i skip-core-infrastructure. Tenker det er greit å validere om det er repository_dispatch som ikke funker eller at det er et nytt repo vi ikke har riktige tilganger til