### PR TITLE
Mulighet for run-terraform fra branch

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -3,8 +3,8 @@ name: Run Terraform
 on:
   workflow_call:
     inputs:
-      force_terraform_apply:
-        description: "Terraform apply normally runs only on a push event to `main`. Setting this to true forces apply (e.g. when run from a pull request)."
+      terraform_apply:
+        description: "If this is not set, terraform apply runs on a push event to `main`. This flag (true/false) can override this behaviour (e.g. when run from a pull request)."
         required: false
         type: string
       comment_on_pr:
@@ -154,6 +154,6 @@ jobs:
 
       - name: Terraform Apply
         uses: kartverket/actions/terraform/apply@v0.2.0
-        if: inputs.force_terraform_apply == 'true' || github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: inputs.terraform_apply == 'true' || github.ref == 'refs/heads/main' && github.event_name == 'push' && inputs.terraform_apply != 'false'
         with:
           path: ${{ env.WORKING_DIRECTORY }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -3,6 +3,10 @@ name: Run Terraform
 on:
   workflow_call:
     inputs:
+      force_terraform_apply:
+        description: "Terraform apply normally runs only on a push event to `main`. Setting this to true forces apply (e.g. when run from a pull request)."
+        required: false
+        type: string
       comment_on_pr:
         description: "Should a Terraform plan comment be generated for the PR? [true/false] Requires 'pull-requests: write'"
         required: false
@@ -150,6 +154,6 @@ jobs:
 
       - name: Terraform Apply
         uses: kartverket/actions/terraform/apply@v0.2.0
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: inputs.force_terraform_apply == 'true' || github.ref == 'refs/heads/main' && github.event_name == 'push'
         with:
           path: ${{ env.WORKING_DIRECTORY }}


### PR DESCRIPTION
Default oppførsel er at `terraform apply` bare kjøres ved push/merge til `main`, men i noen kontekster kan det være ønskelig å kjøre mot et annet miljø ved PR.