### PR TITLE
Legg config.share direkte i bøtten

### DIFF
--- a/terraform/modules/db2open_v2/scripts/main.py
+++ b/terraform/modules/db2open_v2/scripts/main.py
@@ -2,6 +2,8 @@ from databricks.sdk import WorkspaceClient
 import os
 import datetime
 import json
+import requests
+from urllib.parse import urlparse
 from google.cloud import storage
 
 days = float(os.environ.get("DAYS", "1"))
@@ -9,11 +11,22 @@ hours = float(os.environ.get("HOURS", "0"))
 minutes = float(os.environ.get("MINUTES", "0"))
 seconds = float(os.environ.get("SECONDS", "0"))
 
+def _build_activation_url(databricks_host: str, activation_token: str) -> str:
+    """
+    Build the public activation endpoint URL from the configured workspace host.
+    """
+    parsed = urlparse(databricks_host if databricks_host.startswith("http") else f"https://{databricks_host}")
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    return f"{base}/api/2.1/unity-catalog/public/data_sharing_activation/{activation_token}"
+
 def main(request):
     print("os.environ")
     print(os.environ)
-    delta_share_name = os.environ.get("DELTA_SHARE_NAME", None)
-    delta_recipient_name = os.environ.get("DELTA_RECIPIENT_NAME", None)
+    delta_share_name = os.environ.get("DELTA_SHARE_NAME")
+    delta_recipient_name = os.environ.get("DELTA_RECIPIENT_NAME")
+    databricks_host = os.environ.get("DATABRICKS_HOST")
+    bucket_name = os.environ.get("BUCKET_NAME")
+    config_file_name = os.environ.get("CONFIG_FILE_NAME", "config.share") 
 
     if delta_share_name is None:
         raise ValueError("Env variable DELTA_SHARE_NAME is required")
@@ -25,7 +38,7 @@ def main(request):
     expiration_timestamp_ms = int(expiration_datetime.timestamp() * 1000)
 
     ws_client = WorkspaceClient(
-        host=os.environ["DATABRICKS_HOST"],
+        host=databricks_host,
         google_service_account=os.environ["DATABRICKS_GOOGLE_SERVICE_ACCOUNT"]
     )
 
@@ -38,21 +51,36 @@ def main(request):
         raise Exception("No tokens found or too many tokens found")
 
     activation_token = rotated_token.tokens[0].activation_url.split("?")[-1]
-    file_content = { "activation_token": activation_token, "expiration_time": expiration_datetime.isoformat() }
-
 
     bucket_name = os.environ["BUCKET_NAME"]
-    file_name = os.environ["TOKEN_FILE_NAME"]
 
     storage_client = storage.Client()
     bucket = storage_client.bucket(bucket_name)
-    blob = bucket.blob(file_name)
 
-    blob.upload_from_string(json.dumps(file_content))
+    activation_endpoint = _build_activation_url(databricks_host, activation_token)
+    resp = requests.get(activation_endpoint, timeout=30)
+    if resp.status_code != 200:
+        raise RuntimeError(f"Failed to fetch share config (HTTP {resp.status_code}): {resp.text}")
 
-    print(f"Activation token written to gs://{bucket_name}/{file_name}")
+    sharing_data = resp.json()
 
-    return 'OK'
+    share_config = {
+        "shareCredentialsVersion": sharing_data.get("shareCredentialsVersion"),
+        "bearerToken": sharing_data.get("bearerToken"),
+        "endpoint": sharing_data.get("endpoint"),
+        "expirationTime": sharing_data.get("expirationTime"),
+    }
+
+    missing = [k for k in ("shareCredentialsVersion", "bearerToken", "endpoint") if not share_config.get(k)]
+    if missing:
+        raise RuntimeError(f"Activation response missing keys: {missing}. Raw: {sharing_data}")
+
+    config_blob = bucket.blob(config_file_name)
+
+    config_blob.upload_from_string(json.dumps(share_config, indent=2), content_type="application/json")
+
+    print(f"Delta Sharing config written to gs://{bucket_name}/{config_file_name}")
+    return "OK"
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I stedet / eller som et alternativ til å legge credentials i bøtten, kan vi legge config.share i bøtten direkte, ved å kalle på lenken på databricks host sammen med activation token