### PR TITLE
Oppdater Pharos til v0.6.3

### DIFF
--- a/.github/workflows/pull-request-actions.yml
+++ b/.github/workflows/pull-request-actions.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Run Pharos"
-        uses: kartverket/pharos@v0.6.1
+        uses: kartverket/pharos@599d3fe4af8bae19fbfda831662e90ee1c406ec2 # v0.6.3
         with:
           allow_severity_level: high


### PR DESCRIPTION
Ref meldinger i #gen-sikkerhet(https://kartverketgroup.slack.com/archives/C04FFERQWNQ/p1774429168490999) så er det nå anbefalt å ta ibruk igjen pharos, oppdatere til nyeste versjon og pinne med commit-sha.