### PR TITLE
TD-2016 - Bruk kv-datacontracts-validator i publish pipeline workflow

### DIFF
--- a/.github/workflows/publish-data-contract.yml
+++ b/.github/workflows/publish-data-contract.yml
@@ -47,7 +47,7 @@ jobs:
               id: octo-sts
               with:
                   scope: kartverket/kv-datacontract-validator
-                  identity: kartverket-repos
+                  identity: kartverket_repos
 
             - name: Checkout
               uses: actions/checkout@v6

--- a/.github/workflows/publish-data-contract.yml
+++ b/.github/workflows/publish-data-contract.yml
@@ -112,7 +112,7 @@ jobs:
             - name: Validate each changed contract file using kv-datacontract-validator
               if: steps.changed_contracts.outputs.changed_files != ''
               run: |
-                  pipx install git+https://oauth2:${{ steps.octo-sts.outputs.token }}@github.com/kartverket/kv-datacontracts-validator.git@main#subdirectory=datacontract-validator
+                  pipx install git+https://oauth2:${{ steps.octo-sts.outputs.token }}@github.com/kartverket/kv-datacontracts-validator.git@v1.0.0#subdirectory=datacontract-validator
                   kvdcv --files ${{ steps.changed_contracts.outputs.changed_files }}
 
             - name: Install dependencies

--- a/.github/workflows/publish-data-contract.yml
+++ b/.github/workflows/publish-data-contract.yml
@@ -113,13 +113,7 @@ jobs:
               if: steps.changed_contracts.outputs.changed_files != ''
               run: |
                   pipx install git+https://oauth2:${{ steps.octo-sts.outputs.token }}@github.com/kartverket/kv-datacontracts-validator.git@main#subdirectory=datacontract-validator
-
-                  IFS=',' read -ra FILES <<< "${{ steps.changed_contracts.outputs.changed_files }}"
-                  for file in "${FILES[@]}"; do
-                  if [[ -n "$file" ]]; then
-                      kvdcv -f "$file"
-                  fi
-                  done
+                  kvdcv --files ${{ steps.changed_contracts.outputs.changed_files }}
 
             - name: Install dependencies
               run: |

--- a/.github/workflows/publish-data-contract.yml
+++ b/.github/workflows/publish-data-contract.yml
@@ -43,12 +43,6 @@ jobs:
     publish-data_contract:
         runs-on: ubuntu-latest
         steps:
-            - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
-              id: octo-sts
-              with:
-                  scope: kartverket/kv-datacontracts-validator
-                  identity: kartverket_repos
-
             - name: Checkout
               uses: actions/checkout@v6
               with:
@@ -108,9 +102,11 @@ jobs:
                   python-version: "3.12"
                   cache: "pip"
 
-            - name: Install dependencies
-              run: |
-                  pip install -r dask-modules/scripts/validate_data_contract/requirements.txt
+            - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+              id: octo-sts
+              with:
+                  scope: kartverket/kv-datacontracts-validator
+                  identity: kartverket_repos
 
             - name: Validate each changed contract file using kv-datacontract-validator
               if: steps.changed_contracts.outputs.changed_files != ''
@@ -123,6 +119,10 @@ jobs:
                       kvdcv -f "$file"
                   fi
                   done
+
+            - name: Install dependencies
+              run: |
+                  pip install -r dask-modules/scripts/validate_data_contract/requirements.txt
 
             - name: Validate data contracts
               if: steps.changed_contracts.outputs.changed_files != ''

--- a/.github/workflows/publish-data-contract.yml
+++ b/.github/workflows/publish-data-contract.yml
@@ -103,6 +103,18 @@ jobs:
               run: |
                   pip install -r dask-modules/scripts/validate_data_contract/requirements.txt
 
+            - name: Validate each changed contract file using kv-datacontract-validator
+              if: steps.changed_contracts.outputs.changed_files != ''
+              run: |
+                  pipx install git+https://github.com/kartverket/kv-datacontracts-validator.git@v0.2.0#subdirectory=datacontract-validator
+
+                  IFS=',' read -ra FILES <<< "${{ steps.changed_contracts.outputs.changed_files }}"
+                  for file in "${FILES[@]}"; do
+                  if [[ -n "$file" ]]; then
+                      kvdcv -f "$file"
+                  fi
+                  done
+
             - name: Validate data contracts
               if: steps.changed_contracts.outputs.changed_files != ''
               run: |

--- a/.github/workflows/publish-data-contract.yml
+++ b/.github/workflows/publish-data-contract.yml
@@ -46,7 +46,7 @@ jobs:
             - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
               id: octo-sts
               with:
-                  scope: kartverket/kv-datacontract-validator
+                  scope: kartverket/kv-datacontracts-validator
                   identity: kartverket_repos
 
             - name: Checkout

--- a/.github/workflows/publish-data-contract.yml
+++ b/.github/workflows/publish-data-contract.yml
@@ -38,6 +38,7 @@ on:
 
 permissions:
     id-token: write # Required for Octo STS
+    contents: read
 
 jobs:
     publish-data_contract:

--- a/.github/workflows/publish-data-contract.yml
+++ b/.github/workflows/publish-data-contract.yml
@@ -115,7 +115,7 @@ jobs:
             - name: Validate each changed contract file using kv-datacontract-validator
               if: steps.changed_contracts.outputs.changed_files != ''
               run: |
-                  pipx install git+https://oauth2:${{ steps.octo-sts.outputs.token }}@github.com/kartverket/kv-datacontracts-validator.git@td-2016-add-chainguard#subdirectory=datacontract-validator
+                  pipx install git+https://oauth2:${{ steps.octo-sts.outputs.token }}@github.com/kartverket/kv-datacontracts-validator.git@main#subdirectory=datacontract-validator
 
                   IFS=',' read -ra FILES <<< "${{ steps.changed_contracts.outputs.changed_files }}"
                   for file in "${FILES[@]}"; do

--- a/.github/workflows/publish-data-contract.yml
+++ b/.github/workflows/publish-data-contract.yml
@@ -69,7 +69,7 @@ jobs:
                     CHANGED_FILES="$(git diff --name-only origin/main...HEAD | grep '^${{ inputs.data_contract_path }}/.*\.\(yml\|yaml\)$' || echo '')"
                   fi
 
-                  CHANGED_FILES_COMMA_SEPARATED="$(echo "$CHANGED_FILES" | tr '\n' ',')"
+                  CHANGED_FILES_COMMA_SEPARATED="$(echo "$CHANGED_FILES" | tr '\n' ',' | sed 's/,$//')"
                   echo "Changed contract files:"
                   echo "\"$CHANGED_FILES_COMMA_SEPARATED\""
                   echo "changed_files=\"$CHANGED_FILES_COMMA_SEPARATED\"" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-data-contract.yml
+++ b/.github/workflows/publish-data-contract.yml
@@ -36,10 +36,19 @@ on:
                 required: false
                 type: string
 
+permissions:
+    id-token: write # Required for Octo STS
+
 jobs:
     publish-data_contract:
         runs-on: ubuntu-latest
         steps:
+            - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+              id: octo-sts
+              with:
+                  scope: kartverket/kv-datacontract-validator
+                  identity: kartverket-repos
+
             - name: Checkout
               uses: actions/checkout@v6
               with:
@@ -106,7 +115,7 @@ jobs:
             - name: Validate each changed contract file using kv-datacontract-validator
               if: steps.changed_contracts.outputs.changed_files != ''
               run: |
-                  pipx install git+https://github.com/kartverket/kv-datacontracts-validator.git@v0.2.0#subdirectory=datacontract-validator
+                  pipx install git+https://oauth2:${{ steps.octo-sts.outputs.token }}@github.com/kartverket/kv-datacontracts-validator.git@td-2016-add-chainguard#subdirectory=datacontract-validator
 
                   IFS=',' read -ra FILES <<< "${{ steps.changed_contracts.outputs.changed_files }}"
                   for file in "${FILES[@]}"; do


### PR DESCRIPTION
Tar i bruk `kv-datacontracts-valdiator` i workflow for å validere datakontrakt
Bruker octo-sts for å få tilgang til repoet og installerer CLI-kommando med bruk av pipx.
Kjører deretter validering på alle kontrakter som har endret seg siden sist. 