### PR TITLE
Splitt ut deploy til apps-repo til egen workflow

### DIFF
--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -23,7 +23,7 @@ jobs:
       image_url: ${{ steps.set_output.outputs.image_url }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -17,17 +17,11 @@ env:
 
 jobs:
   build:
-    name: Build container image
+    name: Build and publish container image
     runs-on: ubuntu-latest
     outputs:
       image_url: ${{ steps.set_output.outputs.image_url }}
     steps:
-      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
-        id: octo-sts
-        with:
-          scope: kartverket/${{ env.APPS_REPO }}
-          identity: ${{ env.IDENTITY }}
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -32,18 +32,18 @@ jobs:
         run: |
           if git diff --quiet HEAD^ HEAD -- ${{ env.CONTEXT_PATH }} && [ "${{ env.MANUAL_DEPLOY_TRIGGER }}" = false ]; then
             echo "No changes in ${{ env.CONTEXT_PATH }}. Skipping build."
-            echo "::set-output name=skip_build::true"
+            echo "skip_build=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=skip_build::false"
+            echo "skip_build=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Login to Github Container Registry
         if: steps.check_changes.outputs.skip_build == 'false'
-        uses: docker/login-action@v2
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ github.token }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         if: steps.check_changes.outputs.skip_build == 'false'
@@ -59,4 +59,4 @@ jobs:
         if: steps.check_changes.outputs.skip_build == 'false'
         id: set_output
         run: |
-          echo "image_url=${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}" >> $GITHUB_OUTPUT
+          echo "image_url=${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -1,0 +1,68 @@
+name: Build and publish Docker Image
+
+on:
+  workflow_call:
+    inputs:
+      context_path:
+        required: true
+        type: string
+
+    outputs:
+      image_url:
+        value: ${{ jobs.build.outputs.image_url }}
+
+env:
+  REGISTRY: ghcr.io
+  CONTEXT_PATH: ${{ inputs.context_path }}
+
+jobs:
+  build:
+    name: Build container image
+    runs-on: ubuntu-latest
+    outputs:
+      image_url: ${{ steps.set_output.outputs.image_url }}
+    steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
+        id: octo-sts
+        with:
+          scope: kartverket/${{ env.APPS_REPO }}
+          identity: ${{ env.IDENTITY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes in context path
+        id: check_changes
+        run: |
+          if git diff --quiet HEAD^ HEAD -- ${{ env.CONTEXT_PATH }} && [ "${{ env.MANUAL_DEPLOY_TRIGGER }}" = false ]; then
+            echo "No changes in ${{ env.CONTEXT_PATH }}. Skipping build."
+            echo "::set-output name=skip_build::true"
+          else
+            echo "::set-output name=skip_build::false"
+          fi
+
+      - name: Login to Github Container Registry
+        if: steps.check_changes.outputs.skip_build == 'false'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push Docker image
+        if: steps.check_changes.outputs.skip_build == 'false'
+        id: build-docker
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ env.CONTEXT_PATH }}/Dockerfile
+          context: ${{ env.CONTEXT_PATH }}
+          push: ${{ !github.event.pull_request.draft }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:latest
+
+      - name: Set output with build values
+        if: steps.check_changes.outputs.skip_build == 'false'
+        id: set_output
+        run: |
+          echo "image_url=${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-image-to-apps-repo.yml
+++ b/.github/workflows/deploy-image-to-apps-repo.yml
@@ -3,7 +3,7 @@ name: Deploy image to apps repo
 on:
   workflow_call:
     inputs:
-      context_path:
+      image_url:
         required: true
         type: string
       version_file_name:
@@ -24,23 +24,18 @@ on:
         type: string
         default: false
 
-    outputs:
-      image_url:
-        value: ${{ jobs.build.outputs.image_url }}
-
 env:
   REGISTRY: ghcr.io
   APPS_REPO: ${{ inputs.apps_repo }}
-  BRANCH: ${{ github.head_ref || github.ref_name }}
-  IDENTITY: ${{ inputs.identity }}
-  MANUAL_DEPLOY_TRIGGER: ${{ inputs.manual_deploy_trigger }}
 
 jobs:
-  build:
-    name: Build container image
+  deploy-image-to-apps-repo:
+    name: Deploy image to apps repo
     runs-on: ubuntu-latest
     outputs:
       image_url: ${{ steps.set_output.outputs.image_url }}
+    env:
+      IDENTITY: ${{ inputs.identity }}
     steps:
       - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
         id: octo-sts
@@ -56,6 +51,9 @@ jobs:
           token: ${{ steps.octo-sts.outputs.token }}
 
       - name: Create file
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          MANUAL_DEPLOY_TRIGGER: ${{ inputs.manual_deploy_trigger }}
         run: |
           setup_directory () {
               DIRECTORY=${{ inputs.version_file_directory }}
@@ -78,8 +76,3 @@ jobs:
             git commit -m "Update ${{ inputs.version_file_name }}"
             git push
           fi
-
-      - name: Set output with build values
-        id: set_output
-        run: |
-          echo "image_url=${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-image-to-apps-repo.yml
+++ b/.github/workflows/deploy-image-to-apps-repo.yml
@@ -1,0 +1,85 @@
+name: Deploy image to apps repo
+
+on:
+  workflow_call:
+    inputs:
+      context_path:
+        required: true
+        type: string
+      version_file_name:
+        required: true
+        type: string
+      apps_repo:
+        required: true
+        type: string
+      version_file_directory:
+        description: "Directory where version file with image ref is stored"
+        required: false
+        default: "./versions"
+        type: string
+      identity:
+        required: true
+        type: string
+      manual_deploy_trigger:
+        type: string
+        default: false
+
+    outputs:
+      image_url:
+        value: ${{ jobs.build.outputs.image_url }}
+
+env:
+  REGISTRY: ghcr.io
+  APPS_REPO: ${{ inputs.apps_repo }}
+  BRANCH: ${{ github.head_ref || github.ref_name }}
+  IDENTITY: ${{ inputs.identity }}
+  MANUAL_DEPLOY_TRIGGER: ${{ inputs.manual_deploy_trigger }}
+
+jobs:
+  build:
+    name: Build container image
+    runs-on: ubuntu-latest
+    outputs:
+      image_url: ${{ steps.set_output.outputs.image_url }}
+    steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
+        id: octo-sts
+        with:
+          scope: kartverket/${{ env.APPS_REPO }}
+          identity: ${{ env.IDENTITY }}
+
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          repository: kartverket/${{ env.APPS_REPO }}
+          ref: main
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Create file
+        run: |
+          setup_directory () {
+              DIRECTORY=${{ inputs.version_file_directory }}
+              touch $DIRECTORY/${{ inputs.version_file_name }}
+              echo "\"${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}\"" > $DIRECTORY/${{ inputs.version_file_name }} 
+          }
+
+          if [[ "${{ env.BRANCH }}" == "main" ]] || [[ "${{env.MANUAL_DEPLOY_TRIGGER}}" == "true" ]]; then
+              setup_directory 
+          fi
+
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.email "noreply@kartverket.no"
+          git config --global user.name "DASK CI"
+          git add .
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "Update ${{ inputs.version_file_name }}"
+            git push
+          fi
+
+      - name: Set output with build values
+        id: set_output
+        run: |
+          echo "image_url=${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-image-to-apps-repo.yml
+++ b/.github/workflows/deploy-image-to-apps-repo.yml
@@ -37,14 +37,14 @@ jobs:
     env:
       IDENTITY: ${{ inputs.identity }}
     steps:
-      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
           scope: kartverket/${{ env.APPS_REPO }}
           identity: ${{ env.IDENTITY }}
 
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: kartverket/${{ env.APPS_REPO }}
           ref: main

--- a/.github/workflows/deploy-image-to-apps-repo.yml
+++ b/.github/workflows/deploy-image-to-apps-repo.yml
@@ -27,13 +27,12 @@ on:
 env:
   REGISTRY: ghcr.io
   APPS_REPO: ${{ inputs.apps_repo }}
+  VERSION_FILE_NAME: ${{ inputs.version_file_name }}
 
 jobs:
   deploy-image-to-apps-repo:
     name: Deploy image to apps repo
     runs-on: ubuntu-latest
-    outputs:
-      image_url: ${{ steps.set_output.outputs.image_url }}
     env:
       IDENTITY: ${{ inputs.identity }}
     steps:
@@ -52,13 +51,15 @@ jobs:
 
       - name: Create file
         env:
+          IMAGE_URL: ${{ inputs.image_url }}
+          VERSION_FILE_DIRECTORY: ${{ inputs.version_file_directory }}
           BRANCH: ${{ github.head_ref || github.ref_name }}
           MANUAL_DEPLOY_TRIGGER: ${{ inputs.manual_deploy_trigger }}
         run: |
           setup_directory () {
-              DIRECTORY=${{ inputs.version_file_directory }}
-              touch $DIRECTORY/${{ inputs.version_file_name }}
-              echo "\"${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}\"" > $DIRECTORY/${{ inputs.version_file_name }} 
+              DIRECTORY=${{ env.VERSION_FILE_DIRECTORY }}
+              touch $DIRECTORY/${{ env.VERSION_FILE_NAME }}
+              echo "\"${{ env.IMAGE_URL }}\"" > $DIRECTORY/${{ env.VERSION_FILE_NAME }} 
           }
 
           if [[ "${{ env.BRANCH }}" == "main" ]] || [[ "${{env.MANUAL_DEPLOY_TRIGGER}}" == "true" ]]; then
@@ -73,6 +74,6 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to commit."
           else
-            git commit -m "Update ${{ inputs.version_file_name }}"
+            git commit -m "Update ${{ env.VERSION_FILE_NAME }}"
             git push
           fi

--- a/.github/workflows/deploy-image-to-apps-repo.yml
+++ b/.github/workflows/deploy-image-to-apps-repo.yml
@@ -13,9 +13,9 @@ on:
         required: true
         type: string
       version_file_directory:
-        description: "Directory where version file with image ref is stored"
+        description: Directory where version file with image ref is stored
         required: false
-        default: "./versions"
+        default: ./versions
         type: string
       identity:
         required: true


### PR DESCRIPTION
Splitter workflowen `publish-docker-image.yml` i to:
- `build-and-publish-docker-image.yml`: Bygger og deployer image
- `deploy-image-to-apps-repo.yml`: Bytter ut versjonen av imaget som refereres til i apps-repoet

Dette lar oss kjøre Pharos mellom de to handlingene og evt. stoppe workflowen hvis det finnes sårbarheter som ikke er patchet.

Tanken her blir å legge til de to nye workflowene, migrere, og fjerne den gamle workflowen.

Se https://github.com/kartverket/dask-datamarkedsplass/pull/470 for eksempel på bruk