### PR TITLE
TD-2070 - Fiks bugs i publish datacontract workflow

### DIFF
--- a/.github/workflows/publish-data-contract.yml
+++ b/.github/workflows/publish-data-contract.yml
@@ -41,11 +41,13 @@ permissions:
     contents: read
 
 jobs:
-    publish-data_contract:
+    get-changed-files:
         runs-on: ubuntu-latest
+        outputs:
+            changed_files: ${{ steps.changed_contracts.outputs.changed_files }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.1
               with:
                   fetch-depth: 0
                   ref: ${{ github.ref }}
@@ -70,12 +72,24 @@ jobs:
                   fi
 
                   CHANGED_FILES_COMMA_SEPARATED="$(echo "$CHANGED_FILES" | tr '\n' ',' | sed 's/,$//')"
-                  echo "Changed contract files:"
-                  echo "\"$CHANGED_FILES_COMMA_SEPARATED\""
-                  echo "changed_files=\"$CHANGED_FILES_COMMA_SEPARATED\"" >> $GITHUB_OUTPUT
+                  echo "Changed contract files: $CHANGED_FILES_COMMA_SEPARATED"
+                  echo "changed_files=$CHANGED_FILES_COMMA_SEPARATED" >> $GITHUB_OUTPUT
 
-            - name: Checkout
-              uses: actions/checkout@v6
+    publish-data_contract:
+        needs: get-changed-files
+        if: needs.get-changed-files.outputs.changed_files != ''
+        runs-on: ubuntu-latest
+        env:
+            COLUMNS: 200
+        steps:
+            - name: Checkout main repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.1
+              with:
+                  fetch-depth: 0
+                  ref: ${{ github.ref }}
+
+            - name: Checkout dask-modules
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.1
               with:
                   fetch-depth: 0
                   repository: kartverket/dask-modules
@@ -92,13 +106,13 @@ jobs:
 
             - id: google_auth_compute
               name: Authenticate with Google Cloud
-              uses: google-github-actions/auth@v3
+              uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
               with:
                   workload_identity_provider: ${{ steps.create_workload_identity_provider.outputs.workload_identity_provider }}
                   service_account: ${{ inputs.service_account_compute}}
 
             - name: Setup Python
-              uses: actions/setup-python@v6
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
               with:
                   python-version: "3.12"
                   cache: "pip"
@@ -110,31 +124,33 @@ jobs:
                   identity: kartverket_repos
 
             - name: Validate each changed contract file using kv-datacontract-validator
-              if: steps.changed_contracts.outputs.changed_files != ''
               run: |
                   pipx install git+https://oauth2:${{ steps.octo-sts.outputs.token }}@github.com/kartverket/kv-datacontracts-validator.git@v1.0.0#subdirectory=datacontract-validator
-                  kvdcv --files ${{ steps.changed_contracts.outputs.changed_files }}
+                  kvdcv --files "${{ needs.get-changed-files.outputs.changed_files }}"
 
             - name: Install dependencies
               run: |
                   pip install -r dask-modules/scripts/validate_data_contract/requirements.txt
 
             - name: Validate data contracts
-              if: steps.changed_contracts.outputs.changed_files != ''
               run: |
-                  ENVIRONMENT=${{ inputs.environment }} SERVICE_ACCOUNT=${{ inputs.service_account_compute }} CHANGED_DATA_CONTRACTS="${{ steps.changed_contracts.outputs.changed_files }}" python dask-modules/scripts/validate_data_contract/validate_data_contract.py
+                  python dask-modules/scripts/validate_data_contract/validate_data_contract.py
+              env:
+                  ENVIRONMENT: ${{ inputs.environment }}
+                  SERVICE_ACCOUNT: ${{ inputs.service_account_compute }}
+                  CHANGED_DATA_CONTRACTS: ${{ needs.get-changed-files.outputs.changed_files }}
 
             - id: google_auth_deploy
               name: Authenticate with Google Cloud
               if: inputs.publish_data_contract
-              uses: google-github-actions/auth@v3
+              uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
               with:
                   workload_identity_provider: ${{ steps.create_workload_identity_provider.outputs.workload_identity_provider }}
                   service_account: ${{ inputs.service_account_deploy}}
 
             - name: "Set up Cloud SDK"
               if: inputs.publish_data_contract
-              uses: "google-github-actions/setup-gcloud@v3"
+              uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
               with:
                   version: ">= 363.0.0"
 
@@ -145,23 +161,25 @@ jobs:
                   chmod +x /usr/local/bin/yq
 
             - name: Publish changed contracts as JSON to Pub/Sub
-              if: steps.changed_contracts.outputs.changed_files != '' && inputs.publish_data_contract
+              if: inputs.publish_data_contract
               run: |
-                  IFS=',' read -ra FILES <<< "${{ steps.changed_contracts.outputs.changed_files }}"
+                  IFS=',' read -ra FILES <<< "$CHANGED_DATA_CONTRACTS"
                   for file in "${FILES[@]}"; do
-                    if [[ -z "$file" ]]; then
-                        continue
-                    fi
-                    JSON_CONTENT=$(yq -o json "$file")
-                    if [[ -z "$JSON_CONTENT" ]]; then
-                        echo "Skipping $file: no JSON content"
-                        continue
-                    fi
-                    echo "Publishing $file"
-                    if [[ "${{ inputs.environment }}" == "prod" ]]; then
-                        TOPIC="projects/dataplattform-prod-9b1d/topics/data-contract-topic"
-                    else
-                        TOPIC="projects/dataplattform-dev-d335/topics/data-contract-topic"
-                    fi
-                    gcloud pubsub topics publish "$TOPIC" --message "$JSON_CONTENT"
+                      if [[ -z "$file" ]]; then
+                          continue
+                      fi
+                      JSON_CONTENT=$(yq -o json "$file")
+                      if [[ -z "$JSON_CONTENT" ]]; then
+                          echo "Skipping $file: no JSON content"
+                          continue
+                      fi
+                      echo "Publishing $file"
+                      if [[ "${{ inputs.environment }}" == "prod" ]]; then
+                          TOPIC="projects/dataplattform-prod-9b1d/topics/data-contract-topic"
+                      else
+                          TOPIC="projects/dataplattform-dev-d335/topics/data-contract-test-topic"
+                      fi
+                      gcloud pubsub topics publish "$TOPIC" --message "$JSON_CONTENT"
                   done
+              env:
+                  CHANGED_DATA_CONTRACTS: ${{ needs.get-changed-files.outputs.changed_files }}

--- a/.github/workflows/publish-data-contract.yml
+++ b/.github/workflows/publish-data-contract.yml
@@ -46,7 +46,7 @@ jobs:
         outputs:
             changed_files: ${{ steps.changed_contracts.outputs.changed_files }}
         steps:
-            - name: Checkout
+            - name: Checkout caller repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.1
               with:
                   fetch-depth: 0
@@ -82,7 +82,7 @@ jobs:
         env:
             COLUMNS: 200
         steps:
-            - name: Checkout main repository
+            - name: Checkout caller repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.1
               with:
                   fetch-depth: 0


### PR DESCRIPTION
Fikser flere bugs i publish workflow
- Filtrerer på git diff kommando slik at man kun får med kontrakter som er added, renamed eller modified. Bug bestod i at deleted kontrakter ble plukket opp som endret og forsøkt publisert
- Kontrakter med mellomrom i navnet fikk prosessen til å krasje. Fungerer nå

Andre fikses:
- Pinner actions til commit-sha og oppdaterer alle actions
- Splitter job i to steg og hopper over steg nr 2 hvis ingen endrede kontrakter.