### PR TITLE
TD-2094 Benytt resource_name ved ingestor-update

### DIFF
--- a/.github/workflows/create-ingestor-pr.yml
+++ b/.github/workflows/create-ingestor-pr.yml
@@ -117,8 +117,7 @@ jobs:
       - name: Publish message to Pub/Sub topic
         env:
           PUBSUB_TOPIC: projects/onboarding-bf12/topics/onboarding-prod
-          TEAM_SHORT_NAME: ${{ fromJson(inputs.payload).team_short_name }}
         run: |
-          json_message='{"commit_hash": "${{ github.sha }}", "event_type": "ingestor-configured", "payload": { "team_short_name": "${{ env.TEAM_SHORT_NAME }}" }}'
+          json_message='{"commit_hash": "${{ github.sha }}", "event_type": "ingestor-configured", "payload": { "resource_name": "${{ env.RESOURCE_NAME }}" }}'
 
           gcloud pubsub topics publish ${{ env.PUBSUB_TOPIC }} --message="$json_message"

--- a/scripts/data_ingestor_update.py
+++ b/scripts/data_ingestor_update.py
@@ -71,8 +71,8 @@ def update_tfvar_file(
                      f'deploy_service_account = "{resource_name}-deploy@{project_id}.iam.gserviceaccount.com"\n')
         lines.insert(0, f'project_number = "{project_number}"\n')
         lines.insert(0, f'project_id = "{project_id}"\n')
-        lines.insert(0, f'area_name = "{division}"\n')
-        lines.insert(0, f'team_name = "{resource_name}"\n')
+        lines.insert(0, f'division = "{division}"\n')
+        lines.insert(0, f'resource_name = "{resource_name}"\n')
 
         with open(tfvars_path, 'w') as file:
             file.writelines(lines)


### PR DESCRIPTION
Vi har endret platform-onboarding til å benytte resource_name på toppnivå heller enn team, og må derfor endre her så vi oppdaterer riktig ressurs i Firestore etter at repoet er satt opp.