### PR TITLE
TD-2109 - Feilhåndtering når man lager repo

### DIFF
--- a/.github/workflows/configure-ingestor-repo.yml
+++ b/.github/workflows/configure-ingestor-repo.yml
@@ -29,7 +29,9 @@ jobs:
           github-token: ${{ steps.github_app.outputs.token }}
           script: |
             const repoName = '${{ env.TARGET_REPO }}';
-            const response = await github.request('POST /orgs/{org}/repos', {
+
+            try {
+              const response = await github.request('POST /orgs/{org}/repos', {
                 org: 'kartverket',
                 name: repoName,
                 description: 'data-ingestor-repo for team ${{ env.TEAM_NAME }}. Opprinnelig klonet fra https://github.com/kartverket/dataplattform-kom-i-gang.',
@@ -37,8 +39,15 @@ jobs:
                 headers: {
                   'X-GitHub-Api-Version': '2022-11-28'
                 }
-            });
-            console.log(`Response for creating repo ${repoName}:`, response);
+              });
+              console.log(`Response for creating repo ${repoName}:`, response);
+            } catch (error) {
+              if (error.status === 422 && error.response?.data?.errors?.some(e => e.message === 'name already exists on this account')) {
+                console.log(`Repo ${repoName} already exists, continuing.`);
+              } else {
+                throw error;
+              }
+            }
 
       - name: Set DASK and product team groups as admin
         uses: actions/github-script@v7


### PR DESCRIPTION
Hvis man skulle trenge å kjøre onboardingsworkflowen for et repo som allerede eksisterer burde man bare prøve å opprette repoet og hvis det finnes fra før bør man gå videre til neste steg. 
Denne PRen legger inn feilhåndtering så dette skjer. 