### PR TITLE
TD-2109 - Hent innhold i repoet før man prøver å commite noe til det

### DIFF
--- a/.github/workflows/configure-ingestor-repo.yml
+++ b/.github/workflows/configure-ingestor-repo.yml
@@ -85,10 +85,11 @@ jobs:
           git config --global user.email "noreply@kartverket.no"
           rm -rf .git
           git init
+          git remote add origin https://x-access-token:${{ steps.github_app.outputs.token }}@github.com/kartverket/${{ env.TARGET_REPO }}.git
+          git pull
           git add .
           git commit -m "Initial commit"
           git branch -M main
-          git remote add origin https://x-access-token:${{ steps.github_app.outputs.token }}@github.com/kartverket/${{ env.TARGET_REPO }}.git
           git push -u origin main
 
   configure-repo:

--- a/.github/workflows/configure-ingestor-repo.yml
+++ b/.github/workflows/configure-ingestor-repo.yml
@@ -86,11 +86,15 @@ jobs:
           rm -rf .git
           git init
           git remote add origin https://x-access-token:${{ steps.github_app.outputs.token }}@github.com/kartverket/${{ env.TARGET_REPO }}.git
-          git pull
+          git pull origin main || true
           git add .
-          git commit -m "Initial commit"
-          git branch -M main
-          git push -u origin main
+          if git diff --cached --quiet; then
+            echo "No changes to commit, skipping push"
+          else
+            git commit -m "Initial commit"
+            git branch -M main
+            git push -u origin main
+          fi
 
   configure-repo:
     needs: create_and_clone_repo


### PR DESCRIPTION
Når det kan hende at repoet allerede eksisterer så må vi hente innholdet før vi kan commite noe til det. 
Hvis det ikke er noe changes når vi gjør `git add .` så skipper vi å commite, opprette ny branch og pushe. 