### PR TITLE
TD-2109 - Robustify onboardings-workflow

### DIFF
--- a/.github/workflows/configure-ingestor-repo.yml
+++ b/.github/workflows/configure-ingestor-repo.yml
@@ -95,7 +95,7 @@ jobs:
           rm -rf .git
           git init
           git remote add origin https://x-access-token:${{ steps.github_app.outputs.token }}@github.com/kartverket/${{ env.TARGET_REPO }}.git
-          git pull origin main || true
+          git fetch origin main && git reset origin/main || true
           git add .
           if git diff --cached --quiet; then
             echo "No changes to commit, skipping push"


### PR DESCRIPTION
Fikser slik at man kan kjøre onboarding mot allerede eksisterende repoer for tilfeller der repoet er opprettet fra før. Et eksempel på når dette kan skje er hvis workflowen feiler midtveis.

Dette er testet ved å gjøre manuell dispatch av actionen både for et eksisterende repo (https://github.com/kartverket/dask-modules/actions/runs/26959114257) og for et helt nytt repo (https://github.com/kartverket/dask-modules/actions/runs/26959490357) så dette skal nå 100% certified trust me bro fungere.